### PR TITLE
Add deployment scripts and planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,21 @@ Die Entwicklung einer visuellen Drag-and-Drop-Oberfläche für Claude-Flow v2.0.
 Die Wahl von React, TypeScript und der React Flow (XyFlow)-Bibliothek bietet eine solide technologische Grundlage. Die konsequente Nutzung der tools/batch-Methode ist entscheidend, um die Leistungsprobleme des Backends zu umgehen und eine reaktionsschnelle Anwendung zu schaffen.
 
 Eine gut gestaltete visuelle Schnittstelle hat das Potenzial, das volle Potenzial einer komplexen Orchestrierungsplattform wie Claude-Flow zu erschließen. Sie kann die leistungsstarken Funktionen von Hive-Mind-Intelligenz, neuronalen Netzen und dem umfangreichen Werkzeugsatz einer breiteren Zielgruppe zugänglich machen. Indem sie die Komplexität der Kommandozeile hinter einer intuitiven, grafischen Metapher verbirgt, ermöglicht sie die Erstellung von noch komplexeren, innovativeren und leistungsfähigeren KI-gesteuerten Workflows.
+
+## Server Installation
+
+1. Clone this repository: `git clone <repo-url>`
+2. Run the setup script and follow the prompts:
+   ```bash
+   ./install.sh
+   ```
+   The script installs Docker, Docker Compose and configures NGINX with HTTPS.
+3. Access the UI via `https://<your-domain>` once the containers are running.
+
+### Updating the deployment
+
+To fetch the latest version and rebuild all containers execute:
+```bash
+./update.sh
+```
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --production
+COPY server.js .
+EXPOSE 3008
+CMD ["npm", "start"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "claude-flow-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ws": "^8.17.0"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import http from 'http';
+
+const app = express();
+const server = http.createServer(app);
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', ws => {
+  ws.on('message', msg => {
+    ws.send(JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'ok' }));
+  });
+});
+
+const port = process.env.PORT || 3008;
+server.listen(port, () => {
+  console.log(`MCP server listening on ${port}`);
+});

--- a/code_issues.md
+++ b/code_issues.md
@@ -1,0 +1,4 @@
+# Code Issues
+
+- Lack of automated tests for both frontend and backend.
+- Backend not yet connected to database or implementing MCP specification.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: flowuser
+      POSTGRES_PASSWORD: flowpass
+      POSTGRES_DB: flowdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  backend:
+    build: ./backend
+    depends_on:
+      - postgres
+    environment:
+      DATABASE_URL: postgres://flowuser:flowpass@postgres:5432/flowdb
+    ports:
+      - "3008:3008"
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "80:80"
+
+volumes:
+  pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+read -p "Domain name for HTTPS: " DOMAIN
+read -p "Email for LetsEncrypt: " EMAIL
+read -p "Linux user for Docker: " USERNAME
+
+# Install dependencies
+sudo apt update
+sudo apt install -y docker.io docker-compose nginx certbot python3-certbot-nginx
+
+sudo usermod -aG docker "$USERNAME"
+
+sudo systemctl enable docker
+sudo systemctl start docker
+
+# Build and start containers
+sudo docker-compose build
+sudo docker-compose up -d
+
+# Configure nginx
+sudo tee /etc/nginx/sites-available/claude-flow <<NGINX
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location / {
+        proxy_pass http://localhost:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+NGINX
+
+sudo ln -sf /etc/nginx/sites-available/claude-flow /etc/nginx/sites-enabled/claude-flow
+sudo nginx -t && sudo systemctl reload nginx
+
+sudo certbot --nginx -d "$DOMAIN" -m "$EMAIL" --non-interactive --agree-tos
+
+echo "Installation complete. Access your instance at https://$DOMAIN"

--- a/milestones.md
+++ b/milestones.md
@@ -1,0 +1,26 @@
+# Project Milestones
+
+## Milestone 1 - Environment Setup
+- [x] Create Docker based infrastructure with `docker-compose.yml` for frontend, backend and PostgreSQL.
+- [x] Provide installation script `install.sh` to configure Docker and NGINX with HTTPS.
+- [x] Add `update.sh` script to pull latest code and rebuild containers.
+
+## Milestone 2 - Backend Skeleton
+- [ ] Implement minimal Node based MCP server exposing WebSocket on port 3008.
+- [ ] Connect server to PostgreSQL using environment variable `DATABASE_URL`.
+- [ ] Add basic health check endpoint.
+
+## Milestone 3 - Frontend Integration
+- [ ] Containerize the React application for production.
+- [ ] Establish WebSocket connection from UI to backend MCP server.
+- [ ] Visualize tool list retrieved from `/tools/list` endpoint.
+
+## Milestone 4 - Persistent Sessions
+- [ ] Implement session storage in the backend.
+- [ ] Add load/save functionality in the React flow canvas.
+
+## Milestone 5 - Advanced Features
+- [ ] Live monitoring of hive activity via WebSocket events.
+- [ ] Dashboard for neural network training metrics.
+
+This file will be updated as milestones are completed.

--- a/process_issues.md
+++ b/process_issues.md
@@ -1,0 +1,4 @@
+# Process Issues
+
+- Need formal code review workflow for pull requests.
+- Continuous deployment pipeline not set up yet.

--- a/todo.md
+++ b/todo.md
@@ -1,1 +1,11 @@
- 
+# To-Do
+
+## Open
+- Implement backend MCP API according to `backend.md`.
+- Add persistence layer and migrations for PostgreSQL.
+- Extend React Flow canvas with save/load sessions.
+- Write unit tests for frontend and backend.
+
+## Done
+- Added Docker infrastructure and install/update scripts.
+- Documented milestones and installation process.

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Pulling latest changes..."
+git pull
+
+echo "Rebuilding containers..."
+docker-compose build --no-cache
+
+echo "Restarting stack..."
+docker-compose up -d
+
+echo "Update complete"


### PR DESCRIPTION
## Summary
- include basic Docker infrastructure
- provide install/update shell scripts for server setup
- document new milestones and todo items
- add placeholder backend and containerization
- update README with installation instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688260c14b8c832e8d5807b19902cfe3