### PR TITLE
Add env example for frontend

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+GEMINI_API_KEY=your-gemini-api-key

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.local.example` to `.env.local` and set `GEMINI_API_KEY` to your Gemini API key
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- provide `.env.local.example` with placeholder `GEMINI_API_KEY`
- update frontend README with instructions to copy the example

## Testing
- `npm install` within `backend`
- `npm test` within `backend`

------
https://chatgpt.com/codex/tasks/task_e_688268f0d964832e9b8b5a8a4f20193b