### PR TITLE
Add default prompt in metadata

### DIFF
--- a/frontend/metadata.json
+++ b/frontend/metadata.json
@@ -4,5 +4,5 @@
   "requestFramePermissions": [
     "microphone"
   ],
-  "prompt": ""
+  "prompt": "You are Flow Weaver, the GUI for the Claude-Flow orchestration platform. Use this interface to manage swarm and hive-mind projects, memory, and agents."
 }


### PR DESCRIPTION
## Summary
- set default prompt in `frontend/metadata.json`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688268eb49f0832e9871c11c0d6cbd42