### PR TITLE
Update install.sh for production docker setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,65 +1,83 @@
 #!/bin/bash
 set -e
 
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script as root." >&2
+  exit 1
+fi
+
 read -p "Domain name for HTTPS: " DOMAIN
 read -p "Email for LetsEncrypt: " EMAIL
 read -p "Linux user for Docker: " USERNAME
-read -p "Frontend port [80]: " FRONTEND_PORT
-FRONTEND_PORT=${FRONTEND_PORT:-80}
-read -p "Backend port [3008]: " BACKEND_PORT
-BACKEND_PORT=${BACKEND_PORT:-3008}
+
+FRONTEND_PORT=8080
+BACKEND_PORT=3008
+
+# write configuration for docker compose
+cat > .env <<EOF
+DOMAIN=$DOMAIN
+FRONTEND_PORT=$FRONTEND_PORT
+BACKEND_PORT=$BACKEND_PORT
+EOF
 
 echo "Updating package lists..."
-sudo apt update
+apt update
 
 if ! command -v docker >/dev/null; then
     echo "Installing Docker and Compose plugin..."
-    sudo apt install -y docker.io docker-compose-plugin
+    apt install -y docker.io docker-compose-plugin
 else
     echo "Docker already installed"
 fi
 
 if ! command -v nginx >/dev/null; then
     echo "Installing NGINX..."
-    sudo apt install -y nginx
+    apt install -y nginx
 else
     echo "NGINX already installed"
 fi
 
-sudo apt install -y certbot python3-certbot-nginx
+apt install -y certbot python3-certbot-nginx
 
 echo "Adding $USERNAME to docker group..."
-sudo usermod -aG docker "$USERNAME"
+usermod -aG docker "$USERNAME"
 
 echo "Enabling and starting Docker service..."
-sudo systemctl enable docker
-sudo systemctl start docker
+systemctl enable docker
+systemctl start docker
 
 # Build and start containers
 echo "Building Docker images..."
-export FRONTEND_PORT BACKEND_PORT
-sudo docker compose build
+export FRONTEND_PORT BACKEND_PORT DOMAIN
+docker compose build
 echo "Starting containers..."
-sudo docker compose up -d
+docker compose up -d
 
 # Configure nginx
-sudo tee /etc/nginx/sites-available/claude-flow <<NGINX
+tee /etc/nginx/sites-available/claude-flow <<NGINX
 server {
     listen 80;
     server_name $DOMAIN;
+
+    location ~ ^/(session|tools|health) {
+        proxy_pass http://localhost:${BACKEND_PORT};
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
 
     location / {
         proxy_pass http://localhost:${FRONTEND_PORT};
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
+        try_files \$uri \$uri/ /index.html;
     }
 }
 NGINX
 
-sudo ln -sf /etc/nginx/sites-available/claude-flow /etc/nginx/sites-enabled/claude-flow
-sudo nginx -t && sudo systemctl reload nginx
+ln -sf /etc/nginx/sites-available/claude-flow /etc/nginx/sites-enabled/claude-flow
+nginx -t && systemctl reload nginx
 
-sudo certbot --nginx -d "$DOMAIN" -m "$EMAIL" --non-interactive --agree-tos
+certbot --nginx -d "$DOMAIN" -m "$EMAIL" --non-interactive --agree-tos
 
 echo "Frontend running on port $FRONTEND_PORT"
 echo "Backend running on port $BACKEND_PORT"


### PR DESCRIPTION
## Summary
- simplify `install.sh` for production usage
- require root privileges and remove sudo calls
- persist domain and port configuration to `.env`
- set up nginx to route API requests to backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882703158b4832e9c111832542fd583