### PR TITLE
Implement dynamic tool fetching via WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Diese Schritte sind in `idee.md` im Abschnitt "Der integrierte Workflow" beschri
 Das Frontend basiert auf React, TypeScript und React Flow und setzt eine defensive Kommunikation zum Backend ein. Wichtige Merkmale sind:
 
 - **WebSocketService** mit Heartbeats und Auto-Reconnect, der die gesamte JSON-RPC-Kommunikation kapselt【F:idee.md†L46-L51】.
-- **Dynamische Werkzeugpalette**: Beim Start ruft die UI `tools/list` auf, um alle verfügbaren Tools samt Parametern zu laden【F:idee.md†L50-L51】.
+ - **Dynamische Werkzeugpalette**: Beim Start ruft die UI `tools/list` über die WebSocket-Schnittstelle auf, um alle verfügbaren Tools samt Parametern zu laden【F:idee.md†L50-L51】.
 - **Drag-and-Drop Canvas**, Werkzeugpalette, Inspektor-Panel und Protokollkonsole bilden die wesentlichen UI-Komponenten【F:idee.md†L52-L57】.
 - **Globales Zustandsmanagement** verwaltet Verbindungsstatus, Agenteninformationen und Workflow-Daten【F:idee.md†L58-L62】.
 - Die Kernlogik befindet sich in `App.tsx`, das den globalen Zustand und die Kommunikation mit den KI-Diensten koordiniert【F:frontend/docs.md†L11-L20】.

--- a/frontend/WebSocketService.ts
+++ b/frontend/WebSocketService.ts
@@ -1,0 +1,75 @@
+export type RPCRequest = {
+    id: number;
+    method: string;
+    params?: any;
+};
+
+export type RPCResponse = {
+    id: number | null;
+    result?: any;
+    error?: { code: number; message: string };
+};
+
+class WebSocketService {
+    private ws?: WebSocket;
+    private nextId = 1;
+    private pending: Map<number, (res: RPCResponse) => void> = new Map();
+    private url: string;
+    private heartbeatInterval?: number;
+
+    constructor(url = `ws://${window.location.hostname}:3008`) {
+        this.url = url;
+        this.connect();
+    }
+
+    private connect() {
+        this.ws = new WebSocket(this.url);
+        this.ws.addEventListener('open', () => {
+            this.startHeartbeat();
+        });
+        this.ws.addEventListener('message', ev => {
+            try {
+                const data: RPCResponse = JSON.parse(ev.data as string);
+                const handler = this.pending.get(data.id ?? 0);
+                if (handler) {
+                    handler(data);
+                    this.pending.delete(data.id ?? 0);
+                }
+            } catch {
+                // ignore
+            }
+        });
+        this.ws.addEventListener('close', () => {
+            this.stopHeartbeat();
+            setTimeout(() => this.connect(), 1000);
+        });
+    }
+
+    private startHeartbeat() {
+        this.heartbeatInterval = window.setInterval(() => {
+            if (this.ws?.readyState === WebSocket.OPEN) {
+                this.ws.send('ping');
+            }
+        }, 10000);
+    }
+
+    private stopHeartbeat() {
+        if (this.heartbeatInterval) {
+            clearInterval(this.heartbeatInterval);
+            this.heartbeatInterval = undefined;
+        }
+    }
+
+    call(method: string, params?: any): Promise<any> {
+        const id = this.nextId++;
+        const request: RPCRequest = { jsonrpc: '2.0', id, method, params } as any;
+        return new Promise(resolve => {
+            this.pending.set(id, res => resolve(res.result));
+            this.ws?.send(JSON.stringify(request));
+        });
+    }
+}
+
+export const wsService = new WebSocketService();
+
+export default WebSocketService;

--- a/frontend/components/views/MCPToolsView.tsx
+++ b/frontend/components/views/MCPToolsView.tsx
@@ -1,11 +1,12 @@
 
 import React, { useState } from 'react';
-import { MCP_TOOLS } from '../../constants';
+import useToolList from '../../hooks/useToolList';
 import { Card } from '../UI';
 import { ToolsIcon, ChevronDownIcon } from '../Icons';
 
 const MCPToolsView: React.FC = () => {
-    const [openCategory, setOpenCategory] = useState<string | null>(MCP_TOOLS[0].name);
+    const tools = useToolList();
+    const [openCategory, setOpenCategory] = useState<string | null>(null);
 
     return (
         <div className="animate-fade-in-up space-y-8">
@@ -15,9 +16,9 @@ const MCPToolsView: React.FC = () => {
             </div>
 
             <div className="space-y-4">
-                {MCP_TOOLS.map(category => (
+                {tools.map(category => (
                     <div key={category.name}>
-                        <button 
+                        <button
                             className="w-full text-left bg-slate-800/50 p-4 rounded-lg flex justify-between items-center"
                             onClick={() => setOpenCategory(openCategory === category.name ? null : category.name)}
                         >

--- a/frontend/hooks/useToolList.ts
+++ b/frontend/hooks/useToolList.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import { wsService } from '../WebSocketService';
+import { MCPCategory } from '../types';
+
+export default function useToolList() {
+  const [tools, setTools] = useState<MCPCategory[]>([]);
+
+  useEffect(() => {
+    wsService.call('tools/list').then((result: MCPCategory[]) => setTools(result));
+  }, []);
+
+  return tools;
+}

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './WebSocketService';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {


### PR DESCRIPTION
## Summary
- add `WebSocketService` with heartbeat and auto-reconnect
- fetch tool catalog from backend via JSON-RPC
- update MCP tools browser to use dynamic data
- note WebSocket usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882766d1a64832eaf4e6824614bde4d