### PR TITLE
Update README clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flow Weaver ist eine anspruchsvolle Hybrid-IDE für Claude-Flow. Sie verbindet s
 
 1. Repository klonen und in das Verzeichnis wechseln:
    ```bash
-   git clone <REPO-URL>
+   git clone https://github.com/meinzeug/flowUI.git
    cd flowUI
    ```
 2. Installationsskript ausführbar machen und starten (Root-Rechte erforderlich):


### PR DESCRIPTION
## Summary
- show the exact repo URL in the clone command

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6882831c6c0c832e94211c0ef5142189