### PR TITLE
Move Vite index.html to project root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install
 # Copy the frontend sources and Vite config
 COPY frontend ./frontend
 COPY vite.config.ts ./
+COPY index.html ./
 # Build the production bundle
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Flow Weaver soll sich zu einer vollwertigen Plattform entwickeln. Geplant sind e
 ## Lizenz
 
 Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).
+\nIndex.html befindet sich nun im Projektwurzelverzeichnis.

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -298,7 +298,7 @@ Die Anwendung kommuniziert mit der Gemini API über das `@google/genai` SDK. Die
 
 ## 4. Styles & Design Tokens
 
-Das Styling wird durch eine Kombination aus [Tailwind CSS](https://tailwindcss.com/) und einem globalen Stylesheet in `index.html` realisiert.
+Das Styling wird durch eine Kombination aus [Tailwind CSS](https://tailwindcss.com/) und einem globalen Stylesheet in `index.html` im Projektwurzelverzeichnis realisiert.
 
 ### 4.1. Farben
 

--- a/index.html
+++ b/index.html
@@ -227,6 +227,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/index.tsx"></script>
+    <script type="module" src="/frontend/index.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,11 @@ const require = createRequire(import.meta.url);
 const { defineConfig, loadEnv } = require('./frontend/node_modules/vite');
 
 export default defineConfig(({ mode }) => {
-  const frontendRoot = path.resolve(__dirname, 'frontend');
-  const env = loadEnv(mode, frontendRoot, '');
+  const rootDir = __dirname;
+  const frontendRoot = path.resolve(rootDir, 'frontend');
+  const env = loadEnv(mode, rootDir, '');
   return {
-    root: frontendRoot,
+    root: rootDir,
     build: {
       outDir: path.resolve(__dirname, 'dist')
     },


### PR DESCRIPTION
## Summary
- relocate `index.html` to project root
- adjust Vite build config to use project root
- copy `index.html` in Docker build
- document new file location

## Testing
- `npm test` in `backend`
- `./frontend/node_modules/.bin/vitest run frontend/WebSocketService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6882827fc69c832e8a2c63dfa2500710