### PR TITLE
Add debugging logs and coverage

### DIFF
--- a/coverage_report.txt
+++ b/coverage_report.txt
@@ -1,0 +1,65 @@
+TAP version 13
+# MCP server listening on 0
+# MCP server listening on 0
+# Subtest: GET /health returns ok
+ok 1 - GET /health returns ok
+  ---
+  duration_ms: 204.194322
+  type: 'test'
+  ...
+# MCP server listening on 0
+# Subtest: GET /tools/list returns tool catalog
+ok 2 - GET /tools/list returns tool catalog
+  ---
+  duration_ms: 7.009647
+  type: 'test'
+  ...
+# MCP server listening on 0
+# Subtest: GET /tools/info/:name returns tool details
+ok 3 - GET /tools/info/:name returns tool details
+  ---
+  duration_ms: 7.641886
+  type: 'test'
+  ...
+# MCP server listening on 0
+# Subtest: WebSocket JSON-RPC methods work
+ok 4 - WebSocket JSON-RPC methods work
+  ---
+  duration_ms: 11.404236
+  type: 'test'
+  ...
+# MCP server listening on 0
+# Subtest: session save and load persist data
+ok 5 - session save and load persist data
+  ---
+  duration_ms: 34.849244
+  type: 'test'
+  ...
+# Subtest: memory store and query
+ok 6 - memory store and query
+  ---
+  duration_ms: 18.614502
+  type: 'test'
+  ...
+1..6
+# tests 6
+# suites 0
+# pass 6
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms 574.928142
+# start of coverage report
+# ---------------------------------------------------------------------------------------------------------------------------------------------------
+# file            | line % | branch % | funcs % | uncovered lines
+# ---------------------------------------------------------------------------------------------------------------------------------------------------
+# knexfile.cjs    | 100.00 |   100.00 |  100.00 | 
+# server.js       |  79.78 |    51.28 |  100.00 | 29-36 52-54 68-69 80-81 95 103-104 110-111 120-121 124-125 131-132 142-143 157-161 164-165 182-183
+# test            |        |          |         | 
+#  server.test.js | 100.00 |   100.00 |  100.00 | 
+# tools.js        | 100.00 |   100.00 |  100.00 | 
+# ---------------------------------------------------------------------------------------------------------------------------------------------------
+# all files       |  91.17 |    65.45 |  100.00 | 
+# ---------------------------------------------------------------------------------------------------------------------------------------------------
+# end of coverage report

--- a/error.log
+++ b/error.log
@@ -1,0 +1,1 @@
+2025-07-24T19:13:55Z - User reported 'NullReferenceException in DashboardLoader' when opening FlowUI Dashboard. Unable to locate DashboardLoader in repository. No reproduction steps available.

--- a/session_history.json
+++ b/session_history.json
@@ -1,0 +1,13 @@
+[
+  {
+    "timestamp": "2025-07-24T19:13:48Z",
+    "user_request": "Bitte debugge den Fehler beim Öffnen des FlowUI-Dashboards ('NullReferenceException in DashboardLoader')",
+    "actions": [
+      "Initialized logging files",
+      "Installed backend and frontend dependencies",
+      "Ran backend tests (passed)",
+      "Ran frontend tests (failed due to cross-repo tests)",
+      "Collected coverage for backend"
+    ]
+  }
+]

--- a/test_inputs.json
+++ b/test_inputs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "description": "Open DashboardView component",
+    "status": "pending"
+  }
+]

--- a/test_results.json
+++ b/test_results.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": 1,
+    "result": "not implemented",
+    "pass": false
+  }
+]


### PR DESCRIPTION
## Summary
- initialize debugging log files
- capture session history, test inputs, results, and backend coverage

## Testing
- `npm test` in `backend`
- `NODE_ENV=test node --experimental-test-coverage --test`

------
https://chatgpt.com/codex/tasks/task_e_688285621468832ead8757821de21ddb