### PR TITLE
Add DashboardView test and update docs

### DIFF
--- a/bericht.html
+++ b/bericht.html
@@ -3,22 +3,22 @@
 <head><meta charset="UTF-8"><title>Entwicklungsbericht</title></head>
 <body>
 <h1>Autonomer Sprint 2025-07-24</h1>
-<p>Dieser Bericht fasst die durchgef&uuml;hrten Arbeiten gem&auml;&szlig; <code>order.md</code> zusammen.</p>
+<p>Dieser Bericht fasst die im aktuellen Sprint durchgeführten Arbeiten gemäß <code>order.md</code> zusammen.</p>
 <h2>Aktualisierte Dateien</h2>
 <ul>
-<li><code>frontend/vitest.config.ts</code> – Neue Konfiguration f&uuml;r Vitest, um nur projektrelevante Tests auszuf&uuml;hren.</li>
-<li><code>test_inputs.json</code> und <code>test_results.json</code> – Testlauf protokolliert.</li>
-<li><code>error.log</code> und <code>session_history.json</code> – Neue Session und Testergebnisse eingetragen.</li>
-<li><code>code_issues.md</code> – Hinweis auf behobenes Testproblem erg&auml;nzt.</li>
-<li><code>milestones.md</code> – Sprint "Jul-24b-2025" mit erledigten Tasks hinzugef&uuml;gt.</li>
-<li><code>change.log</code> – Chronik um den heutigen Sprint erweitert.</li>
+<li><code>frontend/vitest.config.ts</code> – Testsuche auf alle Dateien erweitert.</li>
+<li><code>components/views/DashboardView.test.tsx</code> – Neuer Rendering-Test zur Reproduktion des gemeldeten Dashboard-Problems.</li>
+<li><code>test_inputs.json</code> und <code>test_results.json</code> – Neue Testfälle eingetragen.</li>
+<li><code>session_history.json</code> und <code>error.log</code> – Aktuelle Session dokumentiert.</li>
+<li><code>milestones.md</code> – Sprint <em>Jul-24c-2025</em> angelegt.</li>
+<li><code>change.log</code> – Chronik um heutigen Eintrag ergänzt.</li>
 </ul>
-<h2>N&auml;chste Schritte</h2>
+<h2>Nächste Schritte</h2>
 <ol>
-<li>Dokumentation der Debugging-Prozesse abschlie&szlig;en.</li>
-<li>Persistenzschicht und Migrationen im Backend fertigstellen.</li>
-<li>Speicher-/Ladefunktion im React-Flow-Canvas implementieren.</li>
+<li>Bericht in <code>bericht.html</code> vollenden und im nächsten Sprint ergänzen.</li>
+<li>CI/CD-Pipeline für automatisierte Tests einrichten.</li>
+<li>Save/Load Funktion im React Flow Canvas implementieren.</li>
 </ol>
-<p>Alle Tests laufen aktuell ohne Fehler.</p>
+<p>Alle vorhandenen Unit-Tests laufen derzeit ohne Fehler.</p>
 </body>
 </html>

--- a/change.log
+++ b/change.log
@@ -2,3 +2,4 @@
 2025-07-25: Implemented tool info endpoint and added backend tests.
 2025-07-26: Added memory store/query endpoints and updated docs.
 2025-07-24: Configured Vitest to ignore node_modules and ran automated tests.
+2025-07-24: Added DashboardView render test and updated vitest config.

--- a/error.log
+++ b/error.log
@@ -1,2 +1,3 @@
 2025-07-24T19:13:55Z - User reported 'NullReferenceException in DashboardLoader' when opening FlowUI Dashboard. Unable to locate DashboardLoader in repository. No reproduction steps available.
 2025-07-24T19:23:11Z - Ran backend and frontend tests. No NullReferenceException reproduced.
+2025-07-24T19:35:39Z - Added DashboardView render test; still cannot reproduce DashboardLoader error.

--- a/frontend/components/views/DashboardView.test.tsx
+++ b/frontend/components/views/DashboardView.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import DashboardView from './DashboardView';
+import { Project } from '../../types';
+
+beforeAll(() => {
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+const noop = () => {};
+
+const project: Project = {
+  id: 'p1',
+  name: 'Test',
+  description: '',
+  hives: [],
+  files: [],
+  memory: [],
+  settings: {} as any,
+  assistantSettings: {} as any,
+  roadmap: [],
+  daaAgents: [],
+  workflows: [],
+  systemServices: [],
+  integrations: [],
+  apiKeys: [],
+  consensusTopics: [],
+};
+
+describe('DashboardView', () => {
+  it('renders without crashing', () => {
+    render(
+      <DashboardView
+        project={project}
+        onSpawnHive={noop}
+        onUpdateHive={noop}
+        onRunSwarm={noop}
+        onDestroyHive={noop}
+        onInitiateProject={noop}
+        onQueryHoD={noop}
+      />
+    );
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "recharts": "^3.1.0"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^22.14.0",
         "jsdom": "^26.1.0",
         "typescript": "~5.7.2",
@@ -34,6 +35,51 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1041,6 +1087,63 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1464,6 +1567,45 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1536,6 +1678,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -1560,6 +1720,28 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -1853,6 +2035,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2063,6 +2264,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -2284,6 +2496,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -2424,6 +2647,44 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2687,6 +2948,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/symbol-tree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "recharts": "^3.1.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^22.14.0",
     "jsdom": "^26.1.0",
     "typescript": "~5.7.2",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   root: '.',
   test: {
-    include: ['WebSocketService.test.ts'],
+    include: ['**/*.test.ts?(x)'],
     environment: 'jsdom'
   }
 })

--- a/milestones.md
+++ b/milestones.md
@@ -58,3 +58,9 @@ This file will be updated as milestones are completed.
 - [x] **Bugfix:** Configure Vitest to run only project tests. (@frontend-agent)
 - [x] **Test:** Ensure backend and frontend tests pass. (@qa-agent)
 - [ ] **Doc:** Document debugging process in bericht.html. (@frontend-agent)
+## Sprint Jul-24c-2025
+*Start:* 2025-07-24  \
+*End:* 2025-07-26  \
+*Lead:* Codex Team
+- [x] **Test:** Add DashboardView render test and update vitest config. (@frontend-agent)
+- [ ] **Doc:** Summarize progress in bericht.html. (@frontend-agent)

--- a/session_history.json
+++ b/session_history.json
@@ -18,5 +18,15 @@
       "Configured vitest",
       "Updated test results"
     ]
+  },
+  {
+    "timestamp": "2025-07-24T19:35:39Z",
+    "user_request": "Automated sprint per order.md",
+    "actions": [
+      "Installed dependencies",
+      "Added DashboardView test",
+      "Updated vitest config",
+      "Ran tests (all passed)"
+    ]
   }
 ]

--- a/test_inputs.json
+++ b/test_inputs.json
@@ -3,5 +3,10 @@
     "id": 1,
     "description": "Open DashboardView component",
     "status": "done"
+  },
+  {
+    "id": 2,
+    "description": "Render DashboardView component",
+    "status": "done"
   }
 ]

--- a/test_results.json
+++ b/test_results.json
@@ -1,4 +1,17 @@
 [
-  {"id": 1, "result": "backend tests pass", "pass": true},
-  {"id": 2, "result": "frontend WebSocketService test pass", "pass": true}
+  {
+    "id": 1,
+    "result": "backend tests pass",
+    "pass": true
+  },
+  {
+    "id": 2,
+    "result": "frontend WebSocketService test pass",
+    "pass": true
+  },
+  {
+    "id": 3,
+    "result": "DashboardView render test pass",
+    "pass": true
+  }
 ]


### PR DESCRIPTION
## Summary
- update vitest config to run all tests
- add render test for DashboardView
- record sprint progress and session history
- document updates in bericht.html

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68828a41c358832e8900a68fb2815ffb