### PR TITLE
Fix install script to clone repo automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ oder mit **wget**
 wget -qO- https://raw.githubusercontent.com/meinzeug/flowUI/main/install.sh | bash
 ```
 
+Das Skript klont das Repository dabei nach `/opt/flowUI` und startet die Container von dort.
+
 Hinweis: Ersetze `main` im URL, falls dein Standard-Branch anders heißt (z. B. `master`). Über `-f` bzw. `-q` bricht der Befehl bei HTTP-Fehlern ab.
 
 Möchtest du das Skript zunächst prüfen, lade es lokal herunter:

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,19 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
+# Determine script location and ensure repository is present
+WORKDIR="/opt/flowUI"
+if [ ! -f docker-compose.yml ]; then
+  echo "docker-compose.yml not found. Cloning repository to $WORKDIR..."
+  apt-get update
+  apt-get install -y git
+  rm -rf "$WORKDIR"
+  git clone https://github.com/meinzeug/flowUI.git "$WORKDIR"
+  cd "$WORKDIR"
+else
+  WORKDIR="$(pwd)"
+fi
+
 read -p "Domain name for HTTPS: " DOMAIN
 read -p "Email for LetsEncrypt: " EMAIL
 read -p "Linux user for Docker: " USERNAME
@@ -103,3 +116,4 @@ certbot --nginx -d "$DOMAIN" -m "$EMAIL" --non-interactive --agree-tos
 echo "Frontend running on port $FRONTEND_PORT"
 echo "Backend running on port $BACKEND_PORT"
 echo "Installation complete. Access your instance at https://$DOMAIN"
+echo "Repository cloned to $WORKDIR"


### PR DESCRIPTION
## Summary
- ensure install.sh works when executed standalone
- document repo location in README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68829f8bb9a0832e87183c1a839ba236