### PR TITLE
Improve install.sh with auto clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ oder mit **wget**
 wget -qO- https://raw.githubusercontent.com/meinzeug/flowUI/main/install.sh | bash
 ```
 
-Das Skript startet Docker Compose im aktuellen Verzeichnis. Fehlt Docker, wird automatisch die
+Das Skript klont das Repository in das Verzeichnis `flowUI` (falls es noch nicht
+existiert) und startet dort Docker Compose. Fehlt Docker, wird automatisch die
 rootlose Variante installiert.
 
 Hinweis: Ersetze `main` im URL, falls dein Standard-Branch anders heißt (z. B. `master`). Über `-f` bzw. `-q` bricht der Befehl bei HTTP-Fehlern ab.

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,18 @@ if [ "$EUID" -eq 0 ]; then
   exit 1
 fi
 
+REPO_URL=${REPO_URL:-https://github.com/meinzeug/flowUI.git}
+REPO_DIR=${REPO_DIR:-flowUI}
+
 if [ ! -f docker-compose.yml ]; then
-
-  echo "docker-compose.yml not found. Please run this script from the project root." >&2
-
-  exit 1
+  echo "docker-compose.yml not found. Cloning repository..."
+  if [ ! -d "$REPO_DIR" ]; then
+    git clone "$REPO_URL" "$REPO_DIR"
+  else
+    echo "Using existing directory $REPO_DIR" >&2
+  fi
+  cd "$REPO_DIR"
+  exec bash install.sh "$@"
 fi
 
 FRONTEND_PORT=8080


### PR DESCRIPTION
## Summary
- make install.sh clone the repo if docker-compose.yml is missing
- document automatic clone in README

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6882a53f1cb8832ea4ac8bdcbe8f2cac