### PR TITLE
Fix docker permission handling in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,17 @@ if ! command -v docker >/dev/null; then
   exit 1
 fi
 
+# Docker command exists but might not be usable (e.g. permission denied)
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker installed but not accessible for the current user. Attempting rootless Docker..."
+  curl -fsSL https://get.docker.com/rootless | sh
+  export PATH="$HOME/bin:$PATH"
+  if ! docker info >/dev/null 2>&1; then
+    echo "Unable to access Docker. Please run this script with sudo or add your user to the docker group." >&2
+    exit 1
+  fi
+fi
+
 echo "Building Docker images..."
 docker compose build
 echo "Starting containers..."


### PR DESCRIPTION
## Summary
- check if Docker is accessible for current user
- if not, attempt rootless Docker installation and warn user

## Testing
- `bash install.sh` *(fails as root: expected)*

------
https://chatgpt.com/codex/tasks/task_e_6882a6a7c2e4832eb203c8f2c1f199c2