### PR TITLE
Fix docker build for frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:18-alpine as build
 WORKDIR /app
-# Install dependencies for the frontend
-COPY frontend/package.json frontend/package-lock.json ./
-RUN npm install
+# Install dependencies for the frontend inside its directory
+COPY frontend/package.json frontend/package-lock.json ./frontend/
+RUN cd frontend && npm install
 # Copy the frontend sources and Vite config
 COPY frontend ./frontend
 COPY vite.config.ts ./
 COPY index.html ./
-# Build the production bundle
-RUN npm run build
+# Build the production bundle using the frontend package
+RUN npm --prefix frontend run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- ensure frontend dependencies are installed inside `frontend` directory when building Docker image

## Testing
- `npm test` in `backend`
- `npm run test` in `frontend`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882aa4562c4832ead3f1d718d467973