### PR TITLE
Improve install script repo handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,6 @@ if [ ! -f docker-compose.yml ]; then
     echo "Using existing directory $REPO_DIR" >&2
   fi
   cd "$REPO_DIR"
-  exec bash install.sh "$@"
 fi
 
 FRONTEND_PORT=8080


### PR DESCRIPTION
## Summary
- avoid re-executing the install script after cloning

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_6882ad6ece18832ea1f6d9884e8656de