### PR TITLE
Add production install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,97 +1,91 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-if [ "$EUID" -eq 0 ]; then
-  echo "Please run this script as a regular user, not as root." >&2
-  exit 1
-fi
+LOGFILE=/var/log/flowui-install.log
+exec > >(tee -a "$LOGFILE") 2>&1
 
-REPO_URL=${REPO_URL:-https://github.com/meinzeug/flowUI.git}
-REPO_DIR=${REPO_DIR:-flowUI}
-
-if [ ! -f docker-compose.yml ]; then
-  echo "docker-compose.yml not found. Cloning repository..."
-  if [ ! -d "$REPO_DIR" ]; then
-    git clone "$REPO_URL" "$REPO_DIR"
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
   else
-    echo "Using existing directory $REPO_DIR" >&2
-  fi
-  cd "$REPO_DIR"
-fi
-
-FRONTEND_PORT=8080
-BACKEND_PORT=3008
-
-read -p "Enter your domain for HTTPS (e.g. example.com): " DOMAIN
-
-if [ -n "$DOMAIN" ]; then
-  docker volume inspect letsencrypt >/dev/null 2>&1 || docker volume create letsencrypt
-  if docker run --rm -v letsencrypt:/etc/letsencrypt alpine sh -c "test -d /etc/letsencrypt/live/$DOMAIN"; then
-    read -p "Existing certificate found for $DOMAIN. Reuse it? [y/N]: " REUSE
-    if [ "$REUSE" != "y" ]; then
-      CERT_NEEDED=yes
-    fi
-  else
-    CERT_NEEDED=yes
-  fi
-
-  if [ "$CERT_NEEDED" = "yes" ]; then
-    read -p "Your name: " CERT_NAME
-    read -p "Email for Let's Encrypt: " CERT_EMAIL
-    docker run --rm -p 80:80 -v letsencrypt:/etc/letsencrypt certbot/certbot certonly --standalone -n --agree-tos -m "$CERT_EMAIL" -d "$DOMAIN"
-  fi
-
-  sed "s/DOMAIN_PLACEHOLDER/$DOMAIN/g" nginx/default.conf.template > nginx/default.conf
-else
-  cp nginx/default.conf.template nginx/default.conf
-fi
-
-cat > .env <<EOF
-FRONTEND_PORT=$FRONTEND_PORT
-BACKEND_PORT=$BACKEND_PORT
-OPENROUTER_API_KEY=$OPENROUTER_API_KEY
-EOF
-
-if ! command -v docker >/dev/null; then
-  echo "Docker not found. Installing rootless Docker..."
-  curl -fsSL https://get.docker.com/rootless | sh
-  export PATH="$HOME/bin:$PATH"
-fi
-
-if ! command -v docker >/dev/null; then
-  echo "Docker installation failed or not in PATH. Please install Docker manually." >&2
-  exit 1
-fi
-
-# Docker command exists but might not be usable (e.g. permission denied)
-if ! docker info >/dev/null 2>&1; then
-  echo "Docker installed but not accessible for the current user. Attempting rootless Docker..."
-  curl -fsSL https://get.docker.com/rootless | sh
-  export PATH="$HOME/bin:$PATH"
-fi
-
-if ! docker info >/dev/null 2>&1; then
-  echo "Unable to access Docker. Adding '$USER' to the docker group (sudo required)..."
-  sudo groupadd -f docker
-  if sudo usermod -aG docker "$USER"; then
-    echo "User added to docker group. Please log out and log back in or run 'newgrp docker' and re-run this script."
-    exit 0
-  else
-    echo "Failed to add user to docker group." >&2
+    echo "This script requires root privileges or sudo." >&2
     exit 1
   fi
-fi
-
-echo "Building Docker images..."
-docker compose build
-echo "Starting containers..."
-docker compose up -d
-
-echo "Frontend running on port $FRONTEND_PORT"
-echo "Backend running on port $BACKEND_PORT"
-if [ -n "$DOMAIN" ]; then
-  echo "Application available at https://$DOMAIN"
 else
-  echo "Application available at http://localhost:$FRONTEND_PORT"
+  SUDO=""
 fi
-echo "Installation complete."
+
+read -rp "Domain for the app (e.g. myapp.example.com): " DOMAIN
+while [ -z "$DOMAIN" ]; do
+  read -rp "Domain cannot be empty. Please enter domain: " DOMAIN
+done
+read -rp "E-mail for Let's Encrypt: " EMAIL
+while [ -z "$EMAIL" ]; do
+  read -rp "E-mail cannot be empty. Please enter e-mail: " EMAIL
+done
+read -rp "Your name: " NAME
+
+echo "\n### Installing required packages..."
+$SUDO apt-get update
+$SUDO apt-get install -y curl git ufw docker.io docker-compose nginx certbot python3-certbot-nginx
+$SUDO systemctl enable --now docker
+
+echo "\n### Configuring firewall..."
+$SUDO ufw allow OpenSSH
+$SUDO ufw allow http
+$SUDO ufw allow https
+$SUDO ufw --force enable
+
+APP_DIR=/opt/flowUI
+if [ ! -d "$APP_DIR" ]; then
+  echo "\n### Cloning repository..."
+  $SUDO git clone https://github.com/meinzeug/flowUI.git "$APP_DIR"
+else
+  echo "\n### Repository already exists. Updating..."
+  $SUDO git -C "$APP_DIR" pull
+fi
+cd "$APP_DIR"
+
+if [ ! -f .env ]; then
+  echo "\n### Creating environment file..."
+  cat <<EENV | $SUDO tee .env
+FRONTEND_PORT=8080
+BACKEND_PORT=3008
+EENV
+fi
+
+$SUDO sed -i '/"443:443"/d' docker-compose.yml
+
+echo "\n### Building and starting Docker containers..."
+$SUDO docker compose up -d --build
+
+NGCONF="/etc/nginx/sites-available/${DOMAIN}"
+if [ ! -f "$NGCONF" ]; then
+  echo "\n### Creating NGINX configuration..."
+  $SUDO tee "$NGCONF" >/dev/null <<NGINX
+server {
+    listen 80;
+    server_name ${DOMAIN};
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+NGINX
+  $SUDO ln -sf "$NGCONF" /etc/nginx/sites-enabled/${DOMAIN}
+fi
+
+$SUDO nginx -t
+$SUDO systemctl reload nginx
+
+echo "\n### Obtaining SSL certificate..."
+$SUDO certbot --nginx --redirect --non-interactive --agree-tos -m "$EMAIL" -d "$DOMAIN"
+$SUDO systemctl enable certbot.timer
+
+echo "\n### Deployment complete"
+echo "Application is available at https://${DOMAIN}"
+echo "Installation performed by ${NAME}"


### PR DESCRIPTION
## Summary
- overhaul `install.sh` with root/sudo setup
- add interactive prompts for domain and email
- install packages, configure ufw
- clone repo to `/opt/flowUI` and start Docker stack
- configure nginx and obtain Let's Encrypt cert

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_6882b1476630832ea2d6f0d348652dce