### PR TITLE
Fix containerd conflict during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,11 @@ read -rp "Your name: " NAME
 
 echo "\n### Installing required packages..."
 $SUDO apt-get update
+# Remove conflicting containerd package if Docker's containerd.io is present
+if dpkg -s containerd >/dev/null 2>&1 && dpkg -s containerd.io >/dev/null 2>&1; then
+  echo "Removing conflicting package 'containerd'..."
+  $SUDO apt-get remove -y containerd
+fi
 $SUDO apt-get install -y curl git ufw docker.io docker-compose nginx certbot python3-certbot-nginx
 $SUDO systemctl enable --now docker
 


### PR DESCRIPTION
## Summary
- update `install.sh` to remove `containerd` if `containerd.io` is also installed

## Testing
- `npm test` in `backend` *(fails: test failed)*
- `npm test` in `frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b2d50e80832eb95ff3ce7f304a34