### PR TITLE
Fix apt removal in cleanup step

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,9 @@ read -rp "Strip packages leaving only SSH and base system? (y/n): " CLEAN_CONFIR
 if [[ $CLEAN_CONFIRM =~ ^[Yy]$ ]]; then
   KEEP_PKGS="openssh-server openssh-client sudo curl wget ufw vim nano lsb-release gnupg iproute2 net-tools"
   ESSENTIAL_PKGS=$(dpkg-query -Wf '${Package} ${Priority} ${Essential}\n' | awk '$2=="required" || $2=="important" || $3=="yes" {print $1}')
-  KEEP_LIST="$KEEP_PKGS $ESSENTIAL_PKGS"
+  # retain apt and all of its dependencies to keep package management functional
+  APT_DEPS=$(apt-cache depends --recurse --installed apt 2>/dev/null | awk '/Depends:/{print $2}' | sort -u)
+  KEEP_LIST="$KEEP_PKGS $ESSENTIAL_PKGS $APT_DEPS apt"
   REMOVE_LIST=$(comm -23 <(dpkg --get-selections | awk '{print $1}' | sort) <(echo "$KEEP_LIST" | tr ' ' '\n' | sort))
   if [ -n "$REMOVE_LIST" ]; then
     echo "Removing packages: $REMOVE_LIST"


### PR DESCRIPTION
## Summary
- ensure the optional cleanup keeps `apt` and its dependencies

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6882baff50ec832eab1dc482f00f0512