### PR TITLE
Fix Docker build by using dynamic Vite import

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,15 @@
 import path from 'path';
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { defineConfig, loadEnv } = require('./frontend/node_modules/vite');
+// Vite's runtime is an ES module. Load it dynamically so this config works
+// when compiled to CommonJS by ts-node during the Docker build.
+const loadVite = async () => await import('./frontend/node_modules/vite');
 
-export default defineConfig(({ mode }) => {
+export default async ({ mode }) => {
+  const { defineConfig, loadEnv } = await loadVite();
   const rootDir = __dirname;
   const frontendRoot = path.resolve(rootDir, 'frontend');
   const env = loadEnv(mode, rootDir, '');
   const apiKey = env.OPENROUTER_API_KEY || env.GEMINI_API_KEY;
-  return {
+  return defineConfig({
     root: rootDir,
     build: {
       outDir: path.resolve(__dirname, 'dist')
@@ -23,5 +24,5 @@ export default defineConfig(({ mode }) => {
         '@': frontendRoot,
       }
     }
-  };
-});
+  });
+};


### PR DESCRIPTION
## Summary
- update `vite.config.ts` to load `vite` dynamically with `import()` so the config works when compiled to CommonJS during Docker builds

## Testing
- `npm --prefix frontend install`
- `npx --prefix frontend vite build`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6882ccd8d9ec832e8d06b75e263e8276