### PR TITLE
Install Python in backend image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm install --production \
+# Install Python and build tools required for node-gyp
+RUN apk add --no-cache python3 make g++ \
+    && npm install --production \
     && npm install -g @anthropic-ai/claude-code claude-flow@alpha
 COPY server.js ./
 COPY tools.js ./


### PR DESCRIPTION
## Summary
- install python3 and build tools in backend Dockerfile so node-gyp can compile native modules

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882d2cc0ae8832eb515b5dbd2be93ad