### PR TITLE
Fix Dockerfile missing curl for claude-flow

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 # Install Python and build tools required for node-gyp
-RUN apk add --no-cache python3 make g++ \
+RUN apk add --no-cache python3 make g++ curl \
     && npm install --production \
     && npm install -g @anthropic-ai/claude-code claude-flow@alpha
 COPY server.js ./


### PR DESCRIPTION
## Summary
- ensure curl is installed in backend Dockerfile to support claude-flow post-install script

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6882d3d1f8bc832e9b3edca6ccaac6f3