### PR TITLE
Fix WebSocket protocol on HTTPS sites

### DIFF
--- a/frontend/WebSocketService.ts
+++ b/frontend/WebSocketService.ts
@@ -17,8 +17,14 @@ class WebSocketService {
     private url: string;
     private heartbeatInterval?: number;
 
-    constructor(url = `ws://${window.location.hostname}:3008`) {
-        this.url = url;
+    constructor(url?: string) {
+        if (url) {
+            this.url = url;
+        } else {
+            const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+            this.url = `${protocol}://${window.location.hostname}:3008`;
+        }
+        
         this.connect();
     }
 


### PR DESCRIPTION
## Summary
- ensure WebSocketService uses `wss` when served over HTTPS

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6882da2351b4832e9b9fac652a6f81d5