### PR TITLE
Improve update.sh remote usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ bash install.sh
    Das Skript baut die Docker-Container und startet sie mit `docker compose`.
 3. Nach Abschluss ist die Oberfläche unter `http://localhost:8080` erreichbar.
 
+### Update des Systems
+
+Nach der Installation kann Flow Weaver jederzeit mit einem einfachen Befehl auf
+den neuesten Stand gebracht werden:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/meinzeug/flowUI/main/update.sh)"
+```
+
+Das Skript aktualisiert das Repository in `/opt/flowUI` und startet die Docker-
+Container neu.
+
 ## Kernidee: Zwei Betriebsmodi
 
 Flow Weaver unterstützt sowohl kurzfristige als auch langfristige Workflows und fasst beide Ansätze in einer einheitlichen Bedienoberfläche zusammen:

--- a/coverage_report.txt
+++ b/coverage_report.txt
@@ -8,54 +8,54 @@ TAP version 13
 # Subtest: GET /health returns ok
 ok 1 - GET /health returns ok
   ---
-  duration_ms: 225.704186
+  duration_ms: 211.401819
   ...
 # MCP server listening on 0
 # Subtest: GET /tools/list returns tool catalog
 ok 2 - GET /tools/list returns tool catalog
   ---
-  duration_ms: 6.697709
+  duration_ms: 6.423092
   ...
 # MCP server listening on 0
 # Subtest: GET /tools/info/:name returns tool details
 ok 3 - GET /tools/info/:name returns tool details
   ---
-  duration_ms: 4.05044
+  duration_ms: 3.990997
   ...
 # MCP server listening on 0
 # Subtest: POST /api/auth/login authenticates user
 ok 4 - POST /api/auth/login authenticates user
   ---
-  duration_ms: 16.062181
+  duration_ms: 16.43222
   ...
 # MCP server listening on 0
 # Subtest: WebSocket JSON-RPC methods work
 ok 5 - WebSocket JSON-RPC methods work
   ---
-  duration_ms: 11.038186
+  duration_ms: 10.423283
   ...
 # MCP server listening on 0
 # Subtest: session save and load persist data
 ok 6 - session save and load persist data
   ---
-  duration_ms: 21.714058
+  duration_ms: 20.920913
   ...
 # MCP server listening on 0
 # Subtest: memory store and query
 ok 7 - memory store and query
   ---
-  duration_ms: 17.501908
+  duration_ms: 34.690033
   ...
 # MCP server listening on 0
 # Subtest: GET /session/list returns saved sessions
 ok 8 - GET /session/list returns saved sessions
   ---
-  duration_ms: 14.371566
+  duration_ms: 14.196211
   ...
 # Subtest: POST /tools/call logs execution
 ok 9 - POST /tools/call logs execution
   ---
-  duration_ms: 6.406279
+  duration_ms: 5.562395
   ...
 1..9
 # tests 9
@@ -65,7 +65,7 @@ ok 9 - POST /tools/call logs execution
 # cancelled 0
 # skipped 0
 # todo 0
-# duration_ms 750.710299
+# duration_ms 695.314547
 # start of coverage report
 # ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # file                | line % | branch % | funcs % | uncovered lines
@@ -86,14 +86,14 @@ ok 9 - POST /tools/call logs execution
  RUN  v3.2.4 /workspace/flowUI/frontend
       Coverage enabled with v8
 
- ✓ WebSocketService.test.ts (1 test) 41ms
- ✓ components/FlowEditor.test.tsx (1 test) 82ms
- ✓ components/views/DashboardView.test.tsx (1 test) 51ms
+ ✓ WebSocketService.test.ts (1 test) 23ms
+ ✓ components/FlowEditor.test.tsx (1 test) 75ms
+ ✓ components/views/DashboardView.test.tsx (1 test) 44ms
 
  Test Files  3 passed (3)
       Tests  3 passed (3)
-   Start at  21:44:51
-   Duration  1.78s (transform 251ms, setup 0ms, collect 817ms, tests 174ms, environment 1.22s, prepare 229ms)
+   Start at  01:22:50
+   Duration  1.72s (transform 190ms, setup 0ms, collect 661ms, tests 142ms, environment 1.23s, prepare 224ms)
 
  % Coverage report from v8
 -------------------|---------|----------|---------|---------|-------------------

--- a/update.sh
+++ b/update.sh
@@ -13,7 +13,24 @@ success() { echo -e "${GREEN}$*${RESET}"; }
 warn() { echo -e "${YELLOW}$*${RESET}"; }
 fail() { echo -e "${RED}$*${RESET}"; }
 
-APP_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Determine application directory. When executed via curl pipe, $0 is "bash"
+# and the script has no physical path. Default to /opt/flowUI which is used by
+# install.sh. If the script resides inside the repository, prefer that location.
+if [ -z "${APP_DIR:-}" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+  if [ -d "$SCRIPT_DIR/.git" ]; then
+    APP_DIR="$SCRIPT_DIR"
+  else
+    APP_DIR="/opt/flowUI"
+  fi
+fi
+
+if [ ! -d "$APP_DIR/.git" ]; then
+  fail "$APP_DIR is not a flowUI repository"
+  exit 1
+fi
+cd "$APP_DIR"
+
 BACKUP_DIR="$APP_DIR/backups"
 TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 BACKUP_FILE="$BACKUP_DIR/flowUI-${TIMESTAMP}.tar.gz"


### PR DESCRIPTION
## Summary
- allow executing `update.sh` via remote `curl` by detecting repository location
- document remote update command in README
- update coverage report

## Testing
- `npm ci` (backend)
- `npm test` (backend)
- `npm run coverage` (backend)
- `npm install` (frontend)
- `npm test` (frontend)
- `npm run coverage` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_6882dbcd1340832eaf277351faef2c6b