### PR TITLE
Improve React dev mode docs and dynamic import map

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,3 +12,16 @@ This contains everything you need to run your app locally.
 2. Copy `.env.local.example` to `.env.local` and set `GEMINI_API_KEY` to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+### Debugging React Errors
+
+When the app is served in production mode, React errors are minified and shown only as codes like "Minified React error #185". Run the frontend in development mode to see the full stack trace:
+
+```bash
+npm run dev
+```
+
+Alternatively, append `?dev` to the import URLs in `index.html` to force the non-minified bundles.
+
+If you see `net::ERR_CERT_COMMON_NAME_INVALID` for `/favicon.ico`, your local HTTPS certificate is likely misconfigured. Use HTTP during development or fix the certificate to remove the warning.
+

--- a/index.html
+++ b/index.html
@@ -212,17 +212,20 @@
       }
 
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.11.0",
-    "recharts": "https://esm.sh/recharts@^3.1.0",
-    "react/": "https://esm.sh/react@^19.1.0/",
-    "react": "https://esm.sh/react@^19.1.0"
-  }
-}
-</script>
+  <script>
+    const devSuffix = location.search.includes('dev') ? '?dev' : '';
+    const imports = {
+      "react-dom/": `https://esm.sh/react-dom@^19.1.0/${devSuffix}`,
+      "@google/genai": "https://esm.sh/@google/genai@^1.11.0",
+      "recharts": "https://esm.sh/recharts@^3.1.0",
+      "react/": `https://esm.sh/react@^19.1.0/${devSuffix}`,
+      "react": `https://esm.sh/react@^19.1.0${devSuffix}`
+    };
+    const script = document.createElement('script');
+    script.type = 'importmap';
+    script.textContent = JSON.stringify({ imports });
+    document.currentScript.after(script);
+  </script>
 <link rel="stylesheet" href="/index.css">
 </head>
   <body>


### PR DESCRIPTION
## Summary
- clarify debugging instructions in frontend README
- use dynamic import map in `index.html` so `?dev` loads non-minified React bundles

## Testing
- `npm test`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882e1cbc4dc832eb19d8acb4a324eb3