### PR TITLE
Add session selector in WorkflowsView

### DIFF
--- a/change.log
+++ b/change.log
@@ -11,3 +11,4 @@ BE-AUTH: 963bda5 2025-07-24 login API
 
 FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 
+2025-07-25: Added session selector and tests for WorkflowsView

--- a/frontend/components/views/WorkflowsView.test.tsx
+++ b/frontend/components/views/WorkflowsView.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import WorkflowsView from './WorkflowsView';
+import { Project } from '../../types';
+
+beforeAll(() => {
+  (global as any).ResizeObserver = class { observe(){} unobserve(){} disconnect(){} };
+});
+
+const noop = () => {};
+
+const project: Project = {
+  id: 'p1',
+  name: 'Test',
+  description: '',
+  hives: [],
+  files: [],
+  memory: [],
+  settings: {} as any,
+  assistantSettings: {} as any,
+  roadmap: [],
+  daaAgents: [],
+  workflows: [],
+  systemServices: [],
+  integrations: [],
+  apiKeys: [],
+  consensusTopics: [],
+};
+
+describe('WorkflowsView', () => {
+  it('fetches session list on mount', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }));
+    (global as any).fetch = fetchMock;
+    render(<WorkflowsView project={project} addLog={noop} onCreateWorkflow={noop} onQueryHoD={noop} />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/session/list'));
+  });
+});

--- a/frontend/components/views/WorkflowsView.tsx
+++ b/frontend/components/views/WorkflowsView.tsx
@@ -1,7 +1,7 @@
 
 
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Project, Workflow, ActivityLogEntry, WorkflowStep, HoDQueryContext } from '../../types';
 import { Card, Button, Modal } from '../UI';
 import { PlusIcon, TerminalIcon, XIcon, HeadOfDevIcon } from '../Icons';
@@ -127,7 +127,14 @@ const WorkflowsView: React.FC<{
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
     const [graph, setGraph] = useState<GraphData | undefined>();
     const [sessionId, setSessionId] = useState<number | null>(null);
+    const [sessions, setSessions] = useState<{id: number; name: string}[]>([]);
 
+    useEffect(() => {
+        fetch('/session/list')
+            .then(res => res.json())
+            .then(data => setSessions(data))
+            .catch(() => {});
+    }, []);
     const handleSaveGraph = async (g: GraphData) => {
         const res = await fetch('/session/save', {
             method: 'POST',
@@ -202,7 +209,17 @@ const WorkflowsView: React.FC<{
             <div className="pt-8">
                 <h3 className="text-xl font-bold text-white mb-2">Workflow Graph</h3>
                 <FlowEditor onSave={handleSaveGraph} initial={graph} />
-                <div className="mt-2 flex gap-2">
+                <div className="mt-2 flex gap-2 items-center">
+                    <select
+                        className="bg-slate-800 border border-slate-700 text-white rounded-lg px-2 py-1"
+                        value={sessionId ?? ''}
+                        onChange={e => setSessionId(e.target.value ? Number(e.target.value) : null)}
+                    >
+                        <option value="">Select Session</option>
+                        {sessions.map(s => (
+                            <option key={s.id} value={s.id}>{s.name}</option>
+                        ))}
+                    </select>
                     <Button variant="secondary" onClick={handleLoadGraph} disabled={!sessionId}>Load</Button>
                 </div>
             </div>

--- a/milestones.md
+++ b/milestones.md
@@ -69,7 +69,7 @@ This file will be updated as milestones are completed.
 *Start:* 2025-07-27  \
 *End:* 2025-07-29  \
 *Lead:* Codex Team
-- [ ] **Feature:** Extend React Flow canvas with save/load sessions. (@frontend-agent)
+- [x] **Feature:** Extend React Flow canvas with save/load sessions. (@frontend-agent)
 - [ ] **Test:** Implement CI/CD pipeline running unit tests. (@qa-agent)
 - [ ] **Bugfix:** Finalize backend MCP API with database persistence. (@backend-agent)
 

--- a/todo.md
+++ b/todo.md
@@ -2,13 +2,12 @@
 
 ## Open
 - Implement backend MCP API according to `backend.md`.
-- Add persistence layer and migrations for PostgreSQL. (in progress)
-- Extend React Flow canvas with save/load sessions.
 - Set up CI/CD pipeline for automated tests.
 
 ## Done
 - Added Docker infrastructure and install/update scripts.
 - Documented milestones and installation process.
 - Implemented database connection and health check in MCP server.
-- Basic unit tests for frontend and backend.
 - Added memory store and query endpoints with tests.
+- Added persistence layer and migrations for PostgreSQL.
+- Extended React Flow canvas with session save/load and selector.


### PR DESCRIPTION
## Summary
- implement session selection dropdown in `WorkflowsView`
- load available sessions from `/session/list`
- add unit test for new behaviour
- update task list and milestones
- log change

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_6882ef9c315c832e8ff739a00ab3acf4