### PR TITLE
Add user authentication with bcrypt

### DIFF
--- a/backend/migrations/20250815000000_create_users.cjs
+++ b/backend/migrations/20250815000000_create_users.cjs
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('users', table => {
+    table.increments('id').primary();
+    table.string('username').notNullable().unique();
+    table.string('email').notNullable().unique();
+    table.string('password_hash').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('users');
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "claude-flow-backend",
       "version": "0.1.0",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "knex": "^2.5.1",
@@ -34,6 +35,20 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -942,6 +957,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-hash": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "migrate": "npx knex --knexfile knexfile.cjs migrate:latest"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "knex": "^2.5.1",


### PR DESCRIPTION
## Summary
- add bcrypt dependency
- create `users` migration
- secure JWT config and hash passwords
- implement `/api/auth/register` and update `/api/auth/login`
- add auth tests and adjust test helpers

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_688341792c24832eb5c87d319fae9e9f