### PR TITLE
Require JWT secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Das Skript klont das Repository nach `/opt/flowUI`, installiert Docker sowie
 NGINX und startet anschließend die Container per `docker compose`. Es benötigt
 Root- bzw. **sudo**‑Rechte und schreibt ein Log nach
 `~/flowui-install.log`.
+Dabei wird auch eine `.env`-Datei mit einem zufälligen `JWT_SECRET` erzeugt.
 
 Hinweis: Ersetze `main` im URL, falls dein Standard-Branch anders heißt (z. B. `master`). Über `-f` bzw. `-q` bricht der Befehl bei HTTP-Fehlern ab.
 
@@ -55,6 +56,11 @@ bash install.sh
    ./install.sh
    ```
    Das Skript baut die Docker-Container und startet sie mit `docker compose`.
+   Dabei wird eine `.env`-Datei mit einem zufälligen `JWT_SECRET` erzeugt,
+   das vom Backend für die Ausgabe von JWT-Tokens benötigt wird. Docker Compose
+   liest diese Variable aus `.env` und reicht sie an den Backend-Container
+   weiter. Wenn du die Container manuell startest, setze das Environment
+   entsprechend.
 3. Nach Abschluss ist die Oberfläche unter `http://localhost:8080` erreichbar.
 
 ### Update des Systems

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -10,6 +10,13 @@ async function startServerWrapper() {
   return startServer(0);
 }
 
+test('server fails to start without JWT_SECRET', { concurrency: 1 }, async () => {
+  const original = process.env.JWT_SECRET;
+  delete process.env.JWT_SECRET;
+  await assert.rejects(() => import('../server.js?' + Date.now()), /JWT_SECRET/);
+  if (original !== undefined) process.env.JWT_SECRET = original;
+});
+
 
 test('GET /health returns ok', { concurrency: 1 }, async () => {
   const server = await startServerWrapper();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - postgres
     environment:
       DATABASE_URL: postgres://flowuser:flowpass@postgres:5432/flowdb
+      JWT_SECRET: ${JWT_SECRET}
     ports:
 
       - "3008:3008"

--- a/install.sh
+++ b/install.sh
@@ -97,10 +97,13 @@ cd "$APP_DIR"
 
 if [ ! -f .env ]; then
   echo "\n### Creating environment file..."
+  JWT_SECRET=$(openssl rand -hex 32)
   cat <<EENV | $SUDO tee .env
 FRONTEND_PORT=8080
 BACKEND_PORT=3008
+JWT_SECRET=$JWT_SECRET
 EENV
+  echo "Generated JWT_SECRET stored in .env"
 fi
 
 # Read ports from environment file for nginx configuration


### PR DESCRIPTION
## Summary
- generate JWT_SECRET in install.sh and pass through docker-compose
- document the variable in README
- add failing startup test when JWT_SECRET is missing

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6883450463b0832e85a01ae3d840e4d2