### PR TITLE
Fix websocket connection path

### DIFF
--- a/frontend/WebSocketService.ts
+++ b/frontend/WebSocketService.ts
@@ -24,7 +24,8 @@ class WebSocketService {
         } else {
             const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
             const host = window.location.host;
-            this.url = `${protocol}://${host}/api`;
+            // Use trailing slash so NGINX location /api/ matches
+            this.url = `${protocol}://${host}/api/`;
         }
         
         this.connect();


### PR DESCRIPTION
## Summary
- adjust WebSocketService URL to include trailing slash

## Testing
- `npm test` in backend
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68834ca91354832e9310a23369decd40