### PR TITLE
Allow custom WebSocket URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ bash install.sh
    liest diese Variable aus `.env` und reicht sie an den Backend-Container
    weiter. Wenn du die Container manuell startest, setze das Environment
    entsprechend.
+   Optional kannst du in `frontend/.env.local` eine Variable `VITE_WS_URL`
+   definieren, um den WebSocket-Endpunkt explizit festzulegen
+   (z. B. `wss://meinzeug.cloud/api/`). Ohne diesen Eintrag wird automatisch
+   der Host der aktuell aufgerufenen Seite verwendet.
 3. Nach Abschluss ist die Oberfläche unter `http://localhost:8080` erreichbar.
 
 ### Update des Systems

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,4 @@
 GEMINI_API_KEY=your-gemini-api-key
 OPENROUTER_API_KEY=your-openrouter-api-key
+# Optional custom WebSocket endpoint, e.g. wss://meinzeug.cloud/api/
+VITE_WS_URL=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,8 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Copy `.env.local.example` to `.env.local` and set `GEMINI_API_KEY` to your Gemini API key
+2. Copy `.env.local.example` to `.env.local` and set `GEMINI_API_KEY` to your Gemini API key.
+   Optionally configure `VITE_WS_URL` if your backend WebSocket endpoint differs.
 3. Run the app:
    `npm run dev`
 

--- a/frontend/WebSocketService.ts
+++ b/frontend/WebSocketService.ts
@@ -21,6 +21,8 @@ class WebSocketService {
     constructor(url?: string) {
         if (url) {
             this.url = url;
+        } else if (import.meta.env.VITE_WS_URL) {
+            this.url = import.meta.env.VITE_WS_URL;
         } else {
             const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
             const host = window.location.host;
@@ -43,6 +45,9 @@ class WebSocketService {
         this.ws = new WebSocket(this.buildUrl());
         this.ws.addEventListener('open', () => {
             this.startHeartbeat();
+        });
+        this.ws.addEventListener('error', () => {
+            console.error('WebSocket connection error');
         });
         this.ws.addEventListener('message', ev => {
             try {


### PR DESCRIPTION
## Summary
- support a custom endpoint via `VITE_WS_URL`
- log WebSocket errors
- document `VITE_WS_URL` in install instructions
- expose the new env var in example file

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68834e24fd90832ebe9e64a91ad6825c