### PR TITLE
Add development mode switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Das Skript aktualisiert das Repository in `/opt/flowUI` und startet die Docker-
 Container neu. Wie beim Installationsskript werden erforderliche Root-Rechte
 automatisch per `sudo` angefordert.
 
+### Betriebsmodus wechseln
+
+Mit `switch.sh` kannst du jederzeit zwischen Produktions- und Entwicklungsmodus umschalten. Im Entwicklungsmodus werden Frontend und Backend direkt aus dem Quellcode gestartet, was Updates wesentlich beschleunigt.
+
+```
+./switch.sh d   # Development
+./switch.sh p   # Production
+```
+
+
 
 ## Kernidee: Zwei Betriebsmodi
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: flowuser
+      POSTGRES_PASSWORD: flowpass
+      POSTGRES_DB: flowdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  backend:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    environment:
+      DATABASE_URL: postgres://flowuser:flowpass@postgres:5432/flowdb
+      JWT_SECRET: ${JWT_SECRET:-devsecret}
+      NODE_ENV: development
+    depends_on:
+      - postgres
+    command: sh -c "npm install && npx knex --knexfile knexfile.cjs migrate:latest && npm start"
+    ports:
+      - "${BACKEND_PORT:-3008}:3008"
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    depends_on:
+      - backend
+    environment:
+      VITE_WS_URL: ${VITE_WS_URL:-}
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+
+volumes:
+  pgdata:

--- a/switch.sh
+++ b/switch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Toggle between production and development Docker Compose setups.
+# Usage: ./switch.sh [p|d]
+set -e
+MODE="$1"
+if [ -z "$MODE" ]; then
+  read -rp "Run environment in (p)roduction or (d)evelopment? " MODE
+fi
+case "$MODE" in
+  p|P|prod|production)
+    rm -f docker-compose.override.yml
+    echo "Switched to production mode.";;
+  d|D|dev|development)
+    ln -sf docker-compose.dev.yml docker-compose.override.yml
+    echo "Switched to development mode.";;
+  *)
+    echo "Usage: $0 [p|d]" >&2
+    exit 1;;
+esac
+
+docker compose down
+FRONTEND_PORT=${FRONTEND_PORT:-8080} BACKEND_PORT=${BACKEND_PORT:-3008} docker compose up -d


### PR DESCRIPTION
## Summary
- add `docker-compose.dev.yml` for a lightweight dev setup
- add `switch.sh` helper to toggle between prod and dev modes
- document new workflow in README

## Testing
- `npm test` in backend
- `npm test` in frontend
- `npm run coverage` in frontend

------
https://chatgpt.com/codex/tasks/task_e_688350b747f0832e852bdfa5be04f028