### PR TITLE
Fix update.sh SSL issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/meinzeug/flowUI/main/upd
 Das Skript aktualisiert das Repository in `/opt/flowUI` und startet die Docker-
 Container neu. Wie beim Installationsskript werden erforderliche Root-Rechte
 automatisch per `sudo` angefordert.
+Wenn du ein externes NGINX mit eigenem TLS-Zertifikat nutzt, kannst du die HTTPS-Portbindung des Containers entfernen, indem du die Variable `REMOVE_HTTPS_PORT=1` setzt:
+
+```bash
+REMOVE_HTTPS_PORT=1 bash update.sh
+```
 
 
 ## Kernidee: Zwei Betriebsmodi

--- a/update.sh
+++ b/update.sh
@@ -100,8 +100,12 @@ info "Updating repository..."
 create_backup
 $SUDO git pull --ff-only
 
-# Remove potential 443 binding to avoid port conflicts
-$SUDO sed -i '/"443:443"/d' docker-compose.yml
+# Optionally remove HTTPS port mapping if a host NGINX proxy handles TLS.
+# Set REMOVE_HTTPS_PORT=1 to delete the "443:443" line from docker-compose.yml.
+if [ "${REMOVE_HTTPS_PORT:-}" = "1" ]; then
+  info "Removing HTTPS port mapping as requested"
+  $SUDO sed -i '/"443:443"/d' docker-compose.yml
+fi
 
 create_nginx_conf
 


### PR DESCRIPTION
## Summary
- make removing 443 port optional via `REMOVE_HTTPS_PORT`
- document optional port removal in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68835218cc74832e84fc7f01252436f0