### PR TITLE
Fix fixssl prompt

### DIFF
--- a/fixssl.sh
+++ b/fixssl.sh
@@ -7,10 +7,10 @@ DOMAIN="${DOMAIN:-${domain:-}}"
 BACKEND_PORT="${BACKEND_PORT:-3008}"
 EMAIL="${EMAIL:-${email:-}}"
 
-if [ -z "$DOMAIN" ]; then
-  echo "DOMAIN variable not set" >&2
-  exit 1
-fi
+while [ -z "$DOMAIN" ]; do
+  read -rp "Domain for the app (e.g. myapp.example.com): " DOMAIN
+done
+
 
 if [ "${EUID:-$(id -u)}" -ne 0 ]; then
   if command -v sudo >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- make `fixssl.sh` prompt for domain if not provided
- keep sudo usage consistent

## Testing
- `npm ci` & `npm test` in `backend`
- `npm run coverage` in `backend`
- `npm ci` & `npm test` in `frontend`
- `npm run coverage` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688355e015ac832e9bac5f9c9adef26c