### PR TITLE
Install certbot nginx plugin in fixssl

### DIFF
--- a/fixssl.sh
+++ b/fixssl.sh
@@ -58,6 +58,9 @@ $SUDO ln -sf "$NGCONF" /etc/nginx/sites-enabled/${DOMAIN}
 $SUDO nginx -t
 $SUDO systemctl reload nginx
 
+# Ensure certbot and the nginx plugin are installed
+$SUDO apt-get install -y certbot python3-certbot-nginx
+
 CERTBOT_ARGS="--nginx --non-interactive --agree-tos --redirect -d ${DOMAIN}"
 if [ -n "$EMAIL" ]; then
   CERTBOT_ARGS="$CERTBOT_ARGS -m $EMAIL"


### PR DESCRIPTION
## Summary
- install certbot and nginx plugin before running certbot

## Testing
- `npm test` in backend
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68835816291c832e83dbf13eeccc1a62