### PR TITLE
Fix unbound variable in switch script

### DIFF
--- a/switch.sh
+++ b/switch.sh
@@ -36,7 +36,7 @@ if [ ! -d "$APP_DIR/.git" ]; then
 fi
 cd "$APP_DIR"
 
-MODE="$1"
+MODE="${1:-}"
 if [ -z "$MODE" ]; then
   read -rp "Run environment in (p)roduction or (d)evelopment? " MODE
 fi


### PR DESCRIPTION
## Summary
- fix `$1` reference by using default expansion so the script runs without args

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883584c7374832eb23706d3f05ca93a