### PR TITLE
Fix WebSocket reconnection on auth updates

### DIFF
--- a/frontend/WebSocketService.ts
+++ b/frontend/WebSocketService.ts
@@ -92,10 +92,15 @@ class WebSocketService {
     }
 
     setAuthToken(token: string | null) {
+        if (this.authToken === token) return;
         this.authToken = token;
-        if (this.ws) {
+        if (!this.ws) {
+            this.connect();
+            return;
+        }
+        if (this.ws.readyState === WebSocket.OPEN) {
             this.ws.close();
-        } else {
+        } else if (this.ws.readyState === WebSocket.CLOSED) {
             this.connect();
         }
     }


### PR DESCRIPTION
## Summary
- avoid closing WebSocket before it is connected
- reconnect only when necessary when updating auth token

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68835e0c971c832ebfbceaaf9839c393