### PR TITLE
Fix login routing with NGINX

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -9,7 +9,10 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://backend:3008/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://backend:3008;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- configure NGINX to keep `/api/` prefix and support WebSocket upgrade

## Testing
- `npm test` in `backend`
- `npm run coverage` in `backend`
- `npm ci` and `npm test` in `frontend`
- `npm run coverage` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883601020bc832eae055e433305e6b4