### PR TITLE
Update update.sh with nginx domain config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/meinzeug/flowUI/main/upd
 Das Skript aktualisiert das Repository in `/opt/flowUI` und startet die Docker-
 Container neu. Wie beim Installationsskript werden erforderliche Root-Rechte
 automatisch per `sudo` angefordert.
+Besitzt die Datei `install.json` einen Domain-Eintrag, passt das Skript zudem die NGINX-Konfiguration im Container an und nutzt das zugehörige Let's-Encrypt-Zertifikat.
 Wenn du ein externes NGINX mit eigenem TLS-Zertifikat nutzt, kannst du die HTTPS-Portbindung des Containers entfernen, indem du die Variable `REMOVE_HTTPS_PORT=1` setzt:
 
 ```bash


### PR DESCRIPTION
## Summary
- update `update.sh` to regenerate `nginx/default.conf` based on the domain
  stored in `install.json`
- document nginx config update in README

## Testing
- `npm ci --ignore-scripts` in backend and run backend tests
- `npm --prefix frontend ci --ignore-scripts` and run frontend tests

------
https://chatgpt.com/codex/tasks/task_e_6883615eab2c832eaae069b4d7dfe89d