### PR TITLE
Implement status endpoint with UI indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
-- Implement /api/status endpoint returning { status: 'ok', userCount }.
-- Display server status in frontend header using new component.
-- Add tests for status endpoint and component.
+- Implement users list endpoint /api/users returning array of {id, username, email}.
+- Create frontend admin view listing users via new endpoint.
+- Add tests for users endpoint and admin component.

--- a/change.log
+++ b/change.log
@@ -16,3 +16,4 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-08-03: Initial Express backend with /api/test route.
 2025-07-25: Added JWT auth middleware, database connection, and tests for Express backend.
 2025-07-25: Added profile endpoint with auth, updated frontend Auth context to load user profile, and added tests.
+2025-07-25: Added /api/status endpoint with user count, frontend ServerStatus component integrated into Header, and tests for both.

--- a/controllers/statusController.js
+++ b/controllers/statusController.js
@@ -1,0 +1,15 @@
+const { initDb, getPool } = require('../db');
+
+async function getStatus(req, res, next) {
+  try {
+    await initDb();
+    const pool = getPool();
+    const { rows } = await pool.query('SELECT COUNT(*) FROM users');
+    const userCount = parseInt(rows[0].count, 10);
+    res.json({ status: 'ok', userCount });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { getStatus };

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { SearchIcon, SettingsIcon } from './Icons';
+import ServerStatus from './ServerStatus';
 
 interface HeaderProps {
   projectName: string;
@@ -15,6 +16,7 @@ const Header: React.FC<HeaderProps> = ({ projectName, onOpenCommandPalette, onOp
         <h2 className="text-2xl font-bold text-white">{projectName}</h2>
       </div>
       <div className="flex items-center gap-4">
+        <ServerStatus />
         <button
             onClick={onOpenCommandPalette}
             className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 w-72 text-slate-400 hover:text-white hover:border-slate-600 transition-colors flex items-center justify-between"

--- a/frontend/components/ServerStatus.test.tsx
+++ b/frontend/components/ServerStatus.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import ServerStatus from './ServerStatus';
+
+describe('ServerStatus', () => {
+  it('fetches status and displays user count', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ status: 'ok', userCount: 3 }) }));
+    (global as any).fetch = fetchMock;
+    const { getByText } = render(<ServerStatus />);
+    await waitFor(() => getByText('Online (3)'));
+    expect(fetchMock).toHaveBeenCalledWith('/api/status');
+  });
+});

--- a/frontend/components/ServerStatus.tsx
+++ b/frontend/components/ServerStatus.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+
+const ServerStatus: React.FC = () => {
+  const [count, setCount] = useState<number | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/status')
+      .then(res => res.json())
+      .then(data => setCount(data.userCount))
+      .catch(() => setError(true));
+  }, []);
+
+  if (error) return <span className="text-red-500">Server Error</span>;
+  if (count === null) return <span className="text-slate-400">Loading...</span>;
+  return <span className="text-green-400">Online ({count})</span>;
+};
+
+export default ServerStatus;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,10 +3,13 @@ const router = express.Router();
 const { testPost } = require('../controllers/testController');
 const { register, login } = require('../controllers/authController');
 const { getProfile } = require('../controllers/profileController');
+const { getStatus } = require('../controllers/statusController');
 const auth = require('../middlewares/auth');
 
 router.post('/auth/register', register);
 router.post('/auth/login', login);
+
+router.get('/status', getStatus);
 
 router.get('/profile', auth, getProfile);
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -95,3 +95,14 @@ test('profile returns user info with token', async () => {
 
   await new Promise(r => server.close(r));
 });
+
+test('GET /api/status returns ok with user count', async () => {
+  const server = await start();
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/api/status`);
+  const data = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(data.status, 'ok');
+  assert.ok(typeof data.userCount === 'number' && data.userCount >= 0);
+  await new Promise(r => server.close(r));
+});


### PR DESCRIPTION
## Summary
- add new `/api/status` route and controller
- show server status in frontend header via `ServerStatus` component
- include tests for backend endpoint and React component
- document feature in change.log
- update AGENTS.md with next tasks

## Testing
- `npm test`
- `(cd backend && npm test)`
- `(cd frontend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68836d39b018832e9badcc84638c53a0