### PR TITLE
Fix frontend HTTPS port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - backend
     ports:
       - "${FRONTEND_PORT:-80}:80"
-      - "443:443"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - letsencrypt:/etc/letsencrypt

--- a/install.sh
+++ b/install.sh
@@ -111,7 +111,12 @@ FRONTEND_PORT="$(grep -oP '^FRONTEND_PORT=\K.*' .env 2>/dev/null || echo 8080)"
 BACKEND_PORT="$(grep -oP '^BACKEND_PORT=\K.*' .env 2>/dev/null || echo 3008)"
 
 
-$SUDO sed -i '/"443:443"/d' docker-compose.yml
+
+# ensure compose file doesn't publish HTTPS port from the frontend container
+if grep -q '"443:443"' docker-compose.yml 2>/dev/null; then
+  echo "Removing obsolete HTTPS port mapping from docker-compose.yml"
+  $SUDO sed -i '/"443:443"/d' docker-compose.yml
+fi
 
 echo "\n### Building and starting Docker containers..."
 $SUDO docker compose up -d --build

--- a/update.sh
+++ b/update.sh
@@ -136,10 +136,9 @@ info "Updating repository..."
 create_backup
 $SUDO git pull --ff-only
 
-# Optionally remove HTTPS port mapping if a host NGINX proxy handles TLS.
-# Set REMOVE_HTTPS_PORT=1 to delete the "443:443" line from docker-compose.yml.
-if [ "${REMOVE_HTTPS_PORT:-}" = "1" ]; then
-  info "Removing HTTPS port mapping as requested"
+# Remove legacy HTTPS port mapping if present
+if grep -q '"443:443"' docker-compose.yml 2>/dev/null; then
+  info "Removing obsolete HTTPS port mapping from docker-compose.yml"
   $SUDO sed -i '/"443:443"/d' docker-compose.yml
 fi
 


### PR DESCRIPTION
## Summary
- remove 443 port exposure from docker-compose
- purge old 443 mapping automatically in install.sh and update.sh

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688370fab124832eaa67265ede54bda6