### PR TITLE
Fix install script for untracked env file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,18 @@ if [ ! -d "$APP_DIR" ]; then
   $SUDO git clone https://github.com/meinzeug/flowUI.git "$APP_DIR"
 else
   echo "\n### Repository already exists. Updating..."
-  $SUDO git -C "$APP_DIR" pull
+  if ! $SUDO git -C "$APP_DIR" pull; then
+    if [ -f "$APP_DIR/.env" ] && ! git -C "$APP_DIR" ls-files --error-unmatch .env >/dev/null 2>&1; then
+      echo "Untracked .env detected, backing up during update..."
+      $SUDO mv "$APP_DIR/.env" "$APP_DIR/.env.bak"
+      $SUDO git -C "$APP_DIR" pull
+      $SUDO mv "$APP_DIR/.env.bak" "$APP_DIR/.env"
+      echo "Restored original .env file"
+    else
+      echo "Failed to update repository." >&2
+      exit 1
+    fi
+  fi
 fi
 cd "$APP_DIR"
 


### PR DESCRIPTION
## Summary
- add handling for untracked `.env` during git update in `install.sh`
- ensure repository update succeeds without overwriting local env file

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688372208518832e94d33967718b4a0b