### PR TITLE
Implement admin users list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
-- Implement users list endpoint /api/users returning array of {id, username, email}.
-- Create frontend admin view listing users via new endpoint.
-- Add tests for users endpoint and admin component.
+- Fix WebSocket handshake issue causing 404 on wss connection.
+- Implement WebSocket endpoint in Express server and ensure Nginx forwards correctly.
+- Add integration tests for WebSocketService connection.

--- a/change.log
+++ b/change.log
@@ -17,3 +17,4 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-07-25: Added JWT auth middleware, database connection, and tests for Express backend.
 2025-07-25: Added profile endpoint with auth, updated frontend Auth context to load user profile, and added tests.
 2025-07-25: Added /api/status endpoint with user count, frontend ServerStatus component integrated into Header, and tests for both.
+2025-07-25: Added /api/users endpoint with admin list view and tests.

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -1,0 +1,14 @@
+const { initDb, getPool } = require('../db');
+
+async function listUsers(req, res, next) {
+  try {
+    await initDb();
+    const pool = getPool();
+    const { rows } = await pool.query('SELECT id, username, email FROM users ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { listUsers };

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -18,6 +18,7 @@ import WorkflowsView from './components/views/WorkflowsView';
 import SystemView from './components/views/SystemView';
 import IntegrationsView from './components/views/IntegrationsView';
 import ApiKeysView from './components/views/ApiKeysView';
+import AdminView from './components/views/AdminView';
 import AssistantSettingsView from './components/views/AssistantSettingsView';
 import AIHeadOfDevelopmentView from './components/views/AIHeadOfDevelopmentView';
 import CommandPalette from './components/CommandPalette';
@@ -1021,6 +1022,8 @@ const App: React.FC = () => {
         return <IntegrationsView project={activeProject} onUpdateIntegration={handleUpdateIntegration} addLog={addLog} />;
       case 'apikeys':
         return <ApiKeysView project={activeProject} onUpdateApiKeys={handleUpdateApiKeys} addLog={addLog} />;
+      case 'admin':
+        return <AdminView />;
       case 'assistant-settings':
         return <AssistantSettingsView project={activeProject} onUpdateSettings={handleUpdateAssistantSettings} addLog={addLog} />;
       default:

--- a/frontend/components/Icons.tsx
+++ b/frontend/components/Icons.tsx
@@ -117,6 +117,12 @@ export const KeyIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
+export const UsersIcon: React.FC<IconProps> = ({ className }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M9 20H4v-2a3 3 0 015.356-1.857M9 20v-2c0-.656.126-1.283.356-1.857M17 10a4 4 0 11-8 0 4 4 0 018 0zM6 8a4 4 0 100 8 4 4 0 000-8z" />
+  </svg>
+);
+
 export const LogoutIcon: React.FC<IconProps> = ({ className }) => (
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className={className}>
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -3,7 +3,7 @@
 
 
 import React, { useState } from 'react';
-import { DashboardIcon, WorkspaceIcon, MemoryIcon, LogoIcon, LogoutIcon, BrainIcon, ToolsIcon, DAAIcon, WorkflowIcon, SystemIcon, IntegrationsIcon, NexusIcon, KeyIcon, ChevronDownIcon, RoadmapIcon, HeadOfDevIcon } from './Icons';
+import { DashboardIcon, WorkspaceIcon, MemoryIcon, LogoIcon, LogoutIcon, BrainIcon, ToolsIcon, DAAIcon, WorkflowIcon, SystemIcon, IntegrationsIcon, NexusIcon, KeyIcon, ChevronDownIcon, RoadmapIcon, HeadOfDevIcon, UsersIcon } from './Icons';
 import { View } from '../types';
 
 interface SidebarProps {
@@ -116,11 +116,17 @@ const Sidebar: React.FC<SidebarProps> = ({ currentView, setCurrentView, onExitPr
             isActive={currentView === 'integrations'}
             onClick={() => setCurrentView('integrations')}
           />
-           <NavItem
+          <NavItem
             icon={<KeyIcon className="h-6 w-6" />}
             label="API Keys"
             isActive={currentView === 'apikeys'}
             onClick={() => setCurrentView('apikeys')}
+          />
+          <NavItem
+            icon={<UsersIcon className="h-6 w-6" />}
+            label="Admin"
+            isActive={currentView === 'admin'}
+            onClick={() => setCurrentView('admin')}
           />
           <NavItem
             icon={<SystemIcon className="h-6 w-6" />}

--- a/frontend/components/views/AdminView.test.tsx
+++ b/frontend/components/views/AdminView.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import AdminView from './AdminView';
+
+describe('AdminView', () => {
+  it('fetches and displays users', async () => {
+    const users = [{ id: 1, username: 'u', email: 'e@test.com', created_at: '' }];
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(users) }));
+    (global as any).fetch = fetchMock;
+    const { getByText } = render(<AdminView />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/users'));
+    expect(getByText('u')).toBeTruthy();
+  });
+});

--- a/frontend/components/views/AdminView.tsx
+++ b/frontend/components/views/AdminView.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { User } from '../../types';
+import { Card } from '../UI';
+
+const AdminView: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(setUsers)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="space-y-4 animate-fade-in-up">
+      <h2 className="text-2xl font-bold text-white">User Management</h2>
+      <Card>
+        <table className="w-full text-left">
+          <thead>
+            <tr>
+              <th className="px-4 py-2">ID</th>
+              <th className="px-4 py-2">Username</th>
+              <th className="px-4 py-2">Email</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(u => (
+              <tr key={u.id} className="border-t border-slate-700">
+                <td className="px-4 py-2">{u.id}</td>
+                <td className="px-4 py-2">{u.username}</td>
+                <td className="px-4 py-2">{u.email}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+};
+
+export default AdminView;

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -82,7 +82,7 @@ export interface HookSettings {
   sessionRestoreHook: Hook;
 }
 
-export type View = "dashboard" | "nexus-roadmap" | "ai-head-of-dev" | "workspace" | "memory" | "settings" | "neural" | "tools" | "daa" | "workflows" | "system" | "integrations" | "apikeys" | "assistant-settings";
+export type View = "dashboard" | "nexus-roadmap" | "ai-head-of-dev" | "workspace" | "memory" | "settings" | "neural" | "tools" | "daa" | "workflows" | "system" | "integrations" | "apikeys" | "assistant-settings" | "admin";
 
 export interface ActivityLogEntry {
     id: number;

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const { testPost } = require('../controllers/testController');
 const { register, login } = require('../controllers/authController');
 const { getProfile } = require('../controllers/profileController');
 const { getStatus } = require('../controllers/statusController');
+const { listUsers } = require('../controllers/usersController');
 const auth = require('../middlewares/auth');
 
 router.post('/auth/register', register);
@@ -12,6 +13,7 @@ router.post('/auth/login', login);
 router.get('/status', getStatus);
 
 router.get('/profile', auth, getProfile);
+router.get('/users', auth, listUsers);
 
 router.post('/test', auth, testPost);
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -106,3 +106,23 @@ test('GET /api/status returns ok with user count', async () => {
   assert.ok(typeof data.userCount === 'number' && data.userCount >= 0);
   await new Promise(r => server.close(r));
 });
+
+test('GET /api/users returns list of users', async () => {
+  const server = await start();
+  const port = server.address().port;
+  const reg = await fetch(`http://localhost:${port}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'dave', email: 'd@d.com', password: 'p' })
+  });
+  const { token } = await reg.json();
+
+  const res = await fetch(`http://localhost:${port}/api/users`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const data = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.ok(Array.isArray(data) && data.length > 0);
+  assert.ok(data[0].username);
+  await new Promise(r => server.close(r));
+});


### PR DESCRIPTION
## Summary
- add GET /api/users endpoint
- create AdminView to list users
- wire up Admin view via sidebar and app routing
- export UsersIcon and add nav item
- include unit tests for endpoint and component
- document changes
- set next tasks in AGENTS.md

## Testing
- `npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883753c1b7c832eabe513d12079d147