### PR TITLE
Implement users endpoint and admin view

### DIFF
--- a/codex.umgebung
+++ b/codex.umgebung
@@ -1,0 +1,17 @@
+# Codex setup script for Flow Weaver project
+# Ensures Node.js dependencies are installed for root, backend and frontend
+# Uses Node 20 which matches CI configuration
+
+setup() {
+  local node_version=20
+  if command -v nvm >/dev/null 2>&1; then
+    nvm install "$node_version"
+    nvm use "$node_version"
+  fi
+
+  npm install
+  (cd backend && npm install)
+  (cd frontend && npm install)
+}
+
+setup "$@"

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -1,0 +1,14 @@
+const { initDb, getPool } = require('../db');
+
+async function listUsers(req, res, next) {
+  try {
+    await initDb();
+    const pool = getPool();
+    const { rows } = await pool.query('SELECT id, username, email FROM users ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { listUsers };

--- a/frontend/components/views/AdminView.test.tsx
+++ b/frontend/components/views/AdminView.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import AdminView from './AdminView';
+
+describe('AdminView', () => {
+  it('fetches and displays users', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 1, username: 'alice', email: 'a@test.com' }]) }));
+    (global as any).fetch = fetchMock;
+    const { getByText } = render(<AdminView />);
+    await waitFor(() => getByText('alice - a@test.com'));
+    expect(fetchMock).toHaveBeenCalledWith('/api/users');
+  });
+});

--- a/frontend/components/views/AdminView.tsx
+++ b/frontend/components/views/AdminView.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { User } from '../../types';
+
+const AdminView: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(data => setUsers(data))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Users</h2>
+      <ul className="space-y-1">
+        {users.map(u => (
+          <li key={u.id}>{u.username} - {u.email}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminView;

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,12 +4,15 @@ const { testPost } = require('../controllers/testController');
 const { register, login } = require('../controllers/authController');
 const { getProfile } = require('../controllers/profileController');
 const { getStatus } = require('../controllers/statusController');
+const { listUsers } = require('../controllers/usersController');
 const auth = require('../middlewares/auth');
 
 router.post('/auth/register', register);
 router.post('/auth/login', login);
 
 router.get('/status', getStatus);
+
+router.get('/users', auth, listUsers);
 
 router.get('/profile', auth, getProfile);
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -96,6 +96,30 @@ test('profile returns user info with token', async () => {
   await new Promise(r => server.close(r));
 });
 
+test('GET /api/users returns users array', async () => {
+  const server = await start();
+  const port = server.address().port;
+  await fetch(`http://localhost:${port}/api/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'dave', email: 'd@d.com', password: 'p' })
+  });
+  const loginRes = await fetch(`http://localhost:${port}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'dave', password: 'p' })
+  });
+  const { token } = await loginRes.json();
+  const res = await fetch(`http://localhost:${port}/api/users`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const data = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.ok(Array.isArray(data));
+  assert.ok(data.some(u => u.username === 'dave'));
+  await new Promise(r => server.close(r));
+});
+
 test('GET /api/status returns ok with user count', async () => {
   const server = await start();
   const port = server.address().port;


### PR DESCRIPTION
## Summary
- create `codex.umgebung` setup script
- add `/api/users` endpoint and controller
- add AdminView component showing user list
- test new endpoint and component

## Testing
- `npm test`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688376bd211c832eabb84a737f7d1696