### PR TITLE
Add GitHub Actions deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+      - name: Run update script on server
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} 'bash -s' < update.sh
+      - name: Record deploy success
+        if: success()
+        run: echo "$(date +%Y-%m-%d), ${{ github.event.workflow_run.head_sha }}, success" >> deploy_log.md
+      - name: Record deploy failure
+        if: failure()
+        run: echo "$(date +%Y-%m-%d), ${{ github.event.workflow_run.head_sha }}, failed" >> deploy_log.md
+      - name: Commit deploy log
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update deployment log"
+          file_pattern: deploy_log.md
+          branch: ${{ github.event.workflow_run.head_branch }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-- Implement continuous deployment pipeline after tests pass.
+Publish Docker images for backend and frontend.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ Wenn du ein externes NGINX mit eigenem TLS-Zertifikat nutzt, kannst du die HTTPS
 REMOVE_HTTPS_PORT=1 bash update.sh
 ```
 
+### Kontinuierliche Bereitstellung
+
+Ein GitHub Actions Workflow sorgt dafür, dass nach erfolgreich durchlaufenen
+Tests automatisch die neueste Version auf dem Zielserver eingespielt wird. Die
+Pipeline triggert das Skript `update.sh` per SSH und hängt das Ergebnis in
+`deploy_log.md` an. Für die Verbindung werden die Secrets `DEPLOY_HOST`,
+`DEPLOY_USER` und `DEPLOY_SSH_KEY` benötigt.
+
+
 ### Betriebsmodus wechseln
 
 Mit `switch.sh` kannst du jederzeit zwischen Produktions- und Entwicklungsmodus umschalten. Im Entwicklungsmodus werden Frontend und Backend direkt aus dem Quellcode gestartet, was Updates wesentlich beschleunigt.

--- a/change.log
+++ b/change.log
@@ -23,4 +23,5 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-07-25: Added persistent hive log endpoints with websocket batch delivery and frontend integration.
 2025-08-04: Added endpoint to clear hive logs with frontend button and tests.
 2025-07-25: Added CI workflow to run backend and frontend tests on each commit
+2025-07-25: Added deployment workflow triggered after tests to run update.sh via SSH.
 

--- a/milestones.md
+++ b/milestones.md
@@ -92,7 +92,7 @@ The following sprints track short term progress inside the larger milestones.
 *End:* 2025-07-29  \
 *Lead:* Codex Team
 - [x] **Feature:** Extend React Flow canvas with save/load sessions. (@frontend-agent)
-- [ ] **Test:** Implement CI/CD pipeline running unit tests. (@qa-agent)
+ - [x] **Test:** Implement CI/CD pipeline running unit tests. (@qa-agent)
 - [ ] **Bugfix:** Finalize backend MCP API with database persistence. (@backend-agent)
 
 ### Sprint Jul-30-2025
@@ -101,7 +101,7 @@ The following sprints track short term progress inside the larger milestones.
 *Lead:* Codex Team
 - [x] **Bugfix:** Investigate and resolve DashboardLoader error. (@frontend-agent)
 - [x] **Doc:** Document debugging outcome in bericht.html. (@frontend-agent)
-- [ ] **Feature:** Prepare deployment scripts for CI/CD pipeline. (@backend-agent)
+ - [x] **Feature:** Prepare deployment scripts for CI/CD pipeline. (@backend-agent)
 
 ### Sprint Aug-02-2025
 *Start:* 2025-08-02  \

--- a/process_issues.md
+++ b/process_issues.md
@@ -1,4 +1,4 @@
 # Process Issues
 
 - Need formal code review workflow for pull requests.
-- Continuous deployment pipeline not set up yet.
+- Continuous deployment pipeline not set up yet. **(resolved)**


### PR DESCRIPTION
## Summary
- add workflow to deploy via SSH after CI succeeds
- document automatic deployment in README
- resolve process issue for missing CD pipeline
- update milestones with completed CI/CD tasks
- log addition in change.log
- set new agent task for publishing Docker images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68838a6446e4832e926ef516ba51f213