### PR TITLE
Add Docker image publication workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,33 @@
+name: Publish Docker Images
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ghcr.io/${{ github.repository }}-backend:latest
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}-frontend:latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,6 @@
-Publish Docker images for backend and frontend.
+- Publish Docker images for backend and frontend.
+- Add GitHub Actions workflow to build and push Docker images to GHCR.
+- Document usage of the published images in README.md.
+- Update deployment process to use prebuilt images by default.
+- Create tests ensuring Dockerfiles build successfully.
+- Document Docker image workflow in milestones and todo lists.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ Pipeline triggert das Skript `update.sh` per SSH und hängt das Ergebnis in
 `deploy_log.md` an. Für die Verbindung werden die Secrets `DEPLOY_HOST`,
 `DEPLOY_USER` und `DEPLOY_SSH_KEY` benötigt.
 
+### Vorgefertigte Docker-Images
+
+Zusätzlich baut ein separater Workflow automatisch Docker-Images und
+veröffentlicht sie im GitHub Container Registry. Du kannst die
+aktuellen Images direkt ziehen:
+
+```bash
+docker pull ghcr.io/<OWNER>/<REPO>-backend:latest
+docker pull ghcr.io/<OWNER>/<REPO>-frontend:latest
+```
+
+Damit lässt sich der Aufbau der Container in eigenen Deployments erheblich
+beschleunigen, da kein lokaler Build-Schritt mehr erforderlich ist.
+
 
 ### Betriebsmodus wechseln
 

--- a/change.log
+++ b/change.log
@@ -25,3 +25,4 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-07-25: Added CI workflow to run backend and frontend tests on each commit
 2025-07-25: Added deployment workflow triggered after tests to run update.sh via SSH.
 
+2025-07-25: Added Docker image publishing workflow and updated README.

--- a/code_issues.md
+++ b/code_issues.md
@@ -3,3 +3,4 @@
 - Only minimal automated tests exist for frontend and backend.
 - Backend not yet connected to database or implementing MCP specification.
 - Frontend tests initially executed node_modules due to missing Vitest config (fixed).
+- No automated workflow to publish Docker images.

--- a/milestones.md
+++ b/milestones.md
@@ -124,3 +124,13 @@ The following sprints track short term progress inside the larger milestones.
 *Lead:* Codex Team
 - [x] **Test:** Add DashboardView render test and update vitest config. (@frontend-agent)
 - [ ] **Doc:** Summarize progress in bericht.html. (@frontend-agent)
+
+### Sprint Aug-05-2025
+*Start:* 2025-08-05  \
+*End:* 2025-08-07  \
+*Lead:* Codex Team
+- [x] **Feature:** Create Docker image publish workflow. (@backend-agent)
+- [ ] **Test:** Verify Dockerfiles build in CI. (@qa-agent)
+- [ ] **Process:** Document image usage and release steps. (@teamlead)
+- [ ] **Doc:** Update README with registry instructions. (@frontend-agent)
+- [ ] **Bugfix:** Update docker-compose to reference images. (@backend-agent)

--- a/process_issues.md
+++ b/process_issues.md
@@ -2,3 +2,4 @@
 
 - Need formal code review workflow for pull requests.
 - Continuous deployment pipeline not set up yet. **(resolved)**
+- Docker image release procedure missing.

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,11 @@
 # To-Do
 
 ## Open
+* Publish Docker images via GitHub Actions
+* Reference published images in docker-compose.yml
+* Add CI step to build Dockerfiles
+* Document Docker registry usage
+* Write tests for Docker container startup
 
 ## Done
 - Set up CI/CD pipeline for automated tests.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish backend and frontend images
- document container registry usage in README
- outline new tasks in AGENTS, milestones and todo
- note missing Docker workflow in issues
- record change in changelog

## Testing
- `npm test --silent`
- `npx vitest --config frontend/vitest.config.ts run --silent`


------
https://chatgpt.com/codex/tasks/task_e_68838d4bab10832e8cc10f9ca5b12116