### PR TITLE
Add user-targeted WS messaging and log export CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-## Nächste Aufgaben (Sprint Aug-15-2025)
-1. [P1] Implementiere Funktion zum Senden von WebSocket-Nachrichten an einen bestimmten Benutzer.
-2. [P1] Erstelle Datenbanktabellen für `projects` und `workflows` inkl. Migration.
-3. [P2] Entwickle CLI-Skript zum Exportieren und Löschen von Hive-Logs.
-4. [P2] Schreibe Unit-Tests für `wsConnections`-Middleware.
-5. [P3] Dokumentiere Installationsschritte für Produktionsdeployment in `README.md`.
+## Nächste Aufgaben (Sprint Aug-18-2025)
+1. [P1] REST-Endpunkte zum Erstellen und Listen von Projekten implementieren
+2. [P1] Workflow-Ausführungs-API mit Queue anlegen
+3. [P2] Hive-Log-API um Pagination erweitern
+4. [P2] React-Komponenten für Projektübersicht und -erstellung bauen
+5. [P3] Dokumentation der neuen Endpunkte in `docs/` ergänzen

--- a/BRAIN.md
+++ b/BRAIN.md
@@ -2,3 +2,4 @@
 - WebSocket-Verbindungen sollen später gezielt pro Benutzer für Tool-Statusmeldungen genutzt werden.
 - Datenbankmodell für Projekte und Workflows ist noch nicht umgesetzt.
 - Automatische Deployment-Pipeline zu einem Cloud-Anbieter geplant.
+- Migrations werden aktuell per SQL in initDb erstellt. Langfristig sollte ein dediziertes Tool wie Knex eingesetzt werden.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,27 @@ docker compose pull
 docker compose up -d
 ```
 
+### Produktionsdeployment
+
+Folgende Schritte richten Flow Weaver auf einem frischen Server ein:
+
+1. Installiere alle Abhängigkeiten mit dem bereitgestellten Install-Skript oder
+   klone das Repository und führe `./install.sh` aus.
+2. Lege in `install.json` deine Domain fest, damit NGINX automatisch ein
+   Let's‑Encrypt-Zertifikat beantragt.
+3. Starte die Container für den Produktivbetrieb:
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+4. Aktualisiere das System später mit `update.sh`, welches den Code zieht,
+   Container neu baut und NGINX neu lädt.
+
+Die Anwendung ist anschließend unter der konfigurierten Domain beziehungsweise
+`http://<server-ip>:8080` erreichbar.
+
 starten.
 
 

--- a/change.log
+++ b/change.log
@@ -29,3 +29,4 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-07-25: Added Docker image publishing workflow and updated README.
 2025-07-25: Updated compose to use GHCR images, added docker build tests and docs.
 2025-08-12: Added JWT WebSocket auth, connection tracking, reconnection tests and compose update.
+2025-08-15: Added sendToUser, project/workflow tables, exportLogs CLI, wsConnections tests, and production docs.

--- a/code_issues.md
+++ b/code_issues.md
@@ -6,3 +6,4 @@
 - No automated workflow to publish Docker images. **(resolved)**
 
 - `frontend/docs.md` enthält keine Beschreibung der WebSocket-Nutzung. Login und Tool-Listen verwenden jedoch `WebSocketService`, wodurch eine fehlende Dokumentation zu Verbindungsfehlern wie 404-Handshakes führt. **(resolved)**
+- Fehlt echtes Migrationsframework, Tabellen werden zur Laufzeit erzeugt.

--- a/db.js
+++ b/db.js
@@ -23,6 +23,20 @@ async function initDb() {
       type TEXT NOT NULL,
       message TEXT NOT NULL
     )`);
+    await pool.query(`CREATE TABLE projects (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER REFERENCES users(id),
+      name TEXT NOT NULL,
+      description TEXT,
+      created_at TIMESTAMP DEFAULT now()
+    )`);
+    await pool.query(`CREATE TABLE workflows (
+      id SERIAL PRIMARY KEY,
+      project_id INTEGER REFERENCES projects(id),
+      name TEXT NOT NULL,
+      definition JSONB NOT NULL,
+      last_run TIMESTAMP
+    )`);
   } else {
     pool = new Pool({ connectionString: DATABASE_URL });
     await pool.query(`CREATE TABLE IF NOT EXISTS users (
@@ -37,6 +51,20 @@ async function initDb() {
       timestamp TIMESTAMP DEFAULT now(),
       type TEXT NOT NULL,
       message TEXT NOT NULL
+    )`);
+    await pool.query(`CREATE TABLE IF NOT EXISTS projects (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER REFERENCES users(id),
+      name TEXT NOT NULL,
+      description TEXT,
+      created_at TIMESTAMP DEFAULT now()
+    )`);
+    await pool.query(`CREATE TABLE IF NOT EXISTS workflows (
+      id SERIAL PRIMARY KEY,
+      project_id INTEGER REFERENCES projects(id),
+      name TEXT NOT NULL,
+      definition JSONB NOT NULL,
+      last_run TIMESTAMP
     )`);
   }
   return pool;

--- a/milestones.md
+++ b/milestones.md
@@ -152,3 +152,13 @@ The following sprints track short term progress inside the larger milestones.
 - [x] **Test:** Wiederverbindungs-Test f\u00fcr WebSocketService. (@qa-agent)
 - [x] **Doc:** WebSocket-API dokumentiert. (@doku-agent)
 - [x] **Config:** Compose-Datei f\u00fcr /ws angepasst. (@teamlead)
+
+### Sprint Aug-15-2025
+*Start:* 2025-08-15  \
+*End:* 2025-08-17  \
+*Lead:* Codex Team
+- [x] **Feature:** Gezielt WebSocket-Nachrichten an Benutzer senden. (@backend-agent)
+- [x] **Feature:** Tabellen `projects` und `workflows` angelegt. (@backend-agent)
+- [x] **Tooling:** CLI zum Exportieren und Löschen von Hive-Logs. (@backend-agent)
+- [x] **Test:** Unit-Tests für wsConnections. (@qa-agent)
+- [x] **Doc:** Produktionsdeploy-Anleitung im README. (@doku-agent)

--- a/scripts/exportLogs.js
+++ b/scripts/exportLogs.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { initDb, getPool } = require('../db');
+
+async function run() {
+  const [, , outfile] = process.argv;
+  await initDb();
+  const pool = getPool();
+  const { rows } = await pool.query('SELECT * FROM activity_log ORDER BY id');
+  const json = JSON.stringify(rows, null, 2);
+  if (outfile) {
+    fs.writeFileSync(outfile, json);
+    console.log(`wrote ${rows.length} logs to ${outfile}`);
+  } else {
+    console.log(json);
+  }
+  await pool.query('DELETE FROM activity_log');
+  console.log('logs cleared');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/wsConnections.test.js
+++ b/test/wsConnections.test.js
@@ -1,0 +1,19 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const EventEmitter = require('events');
+const { storeConnection, getConnections } = require('../middlewares/wsConnections');
+
+function createWs() {
+  const ws = new EventEmitter();
+  ws.readyState = 1;
+  ws.close = () => ws.emit('close');
+  return ws;
+}
+
+test('storeConnection adds and removes connections', () => {
+  const ws = createWs();
+  storeConnection('u1', ws);
+  assert.strictEqual(getConnections('u1').length, 1);
+  ws.close();
+  assert.strictEqual(getConnections('u1').length, 0);
+});

--- a/testcases.md
+++ b/testcases.md
@@ -21,3 +21,13 @@
 4. **WebSocketService Reconnect**
    - Simuliere Schließen der Verbindung im Frontend
    - Erwartet neuen Verbindungsaufbau nach 1 Sekunde
+
+5. **wsConnections Middleware**
+   - Erzeuge Mock-WebSocket und speichere Verbindung mit `storeConnection`
+   - Erwartet, dass `getConnections` die Verbindung liefert
+   - Sende `close`-Event und prüfe, dass sie entfernt wurde
+
+6. **Hive-Log-Export-Skript**
+   - Führe `node scripts/exportLogs.js logs.json` aus
+   - Erwartet Datei `logs.json` mit Log-Einträgen
+   - Tabelle `activity_log` wird danach geleert

--- a/ws.js
+++ b/ws.js
@@ -1,4 +1,5 @@
 const { OPEN } = require('ws');
+const { getConnections } = require('./middlewares/wsConnections');
 let wss;
 
 function setWss(server) {
@@ -15,4 +16,15 @@ function broadcast(event, data) {
   });
 }
 
-module.exports = { setWss, broadcast };
+function sendToUser(userId, event, data) {
+  if (!wss) return;
+  const msg = JSON.stringify({ event, data });
+  const connections = getConnections(userId);
+  connections.forEach(ws => {
+    if (ws.readyState === OPEN) {
+      ws.send(msg);
+    }
+  });
+}
+
+module.exports = { setWss, broadcast, sendToUser };


### PR DESCRIPTION
## Summary
- add `sendToUser` helper to websocket module
- create `projects` and `workflows` tables on DB init
- provide `scripts/exportLogs.js` to export and prune hive logs
- test wsConnections middleware
- document production deployment steps
- update docs and planning files

## Testing
- `node --test test/wsConnections.test.js`
- `npm test` *(fails: hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6883986fd1c0832e9969876ad78cc084