### PR TITLE
Fix docs for WebSocket URL example

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,4 +1,4 @@
 GEMINI_API_KEY=your-gemini-api-key
 OPENROUTER_API_KEY=your-openrouter-api-key
-# Optional custom WebSocket endpoint, e.g. wss://meinzeug.cloud/api/
+# Optional custom WebSocket endpoint, e.g. wss://meinzeug.cloud/ws
 VITE_WS_URL=


### PR DESCRIPTION
## Summary
- correct example WebSocket URL in `frontend/.env.local.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883b51a47fc832ea45392dc2d472eec