### PR TITLE
Enable registration and login on start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Das Frontend basiert auf React, TypeScript und React Flow und setzt eine defensi
 
 ## Backend-Entwicklung
 
-Der Express-Server lauscht standardmäßig auf Port 3008. Nach `npm install` startet er mit `npm start`. Eine Testroute erreicht man über `POST /api/test`.
+Der Express-Server lauscht standardmäßig auf Port 3008. Nach `npm install` baust du zuerst das Frontend mit `npm run build` und startest anschließend mit `npm start`. Eine Testroute erreicht man über `POST /api/test`.
 
 ## Vision
 
@@ -203,4 +203,3 @@ Flow Weaver soll sich zu einer vollwertigen Plattform entwickeln. Geplant sind e
 ## Lizenz
 
 Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).
-\nIndex.html befindet sich nun im Projektwurzelverzeichnis.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "NODE_ENV=test node --test test/*.js"
+    "test": "NODE_ENV=test node --test test/*.js",
+    "build": "npm --prefix frontend run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- serve compiled frontend from `dist` so `/` loads the React app
- add `build` script to compile the frontend
- mention the build step in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883bc0bac1c832eb6c591914e45da13