### PR TITLE
Implement workflow queue and log pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-## Nächste Aufgaben (Sprint Aug-22-2025)
-1. [P1] Workflow-Ausführungs-API mit Queue anlegen
-2. [P2] Hive-Log-API um Pagination erweitern
-3. [P2] React-Komponenten für Projektübersicht und -erstellung bauen
+## Nächste Aufgaben (Sprint Aug-29-2025)
+1. [P1] Worker zur Verarbeitung der Workflow-Queue implementieren
+2. [P2] REST-Endpunkte zum Erstellen und Listen von Workflows ergänzen
+3. [P2] API-Dokumentation für Workflow-Queue aktualisieren

--- a/change.log
+++ b/change.log
@@ -32,3 +32,4 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-08-12: Added JWT WebSocket auth, connection tracking, reconnection tests and compose update.
 2025-08-15: Added sendToUser, project/workflow tables, exportLogs CLI, wsConnections tests, and production docs.
 2025-08-21: Added GHCR authentication with fallback to local build in install.sh, compose build contexts and updated docs.
+2025-08-24: Added workflow execute endpoint with queue, hive log pagination and project components.

--- a/code_issues.md
+++ b/code_issues.md
@@ -7,3 +7,4 @@
 
 - `frontend/docs.md` enthält keine Beschreibung der WebSocket-Nutzung. Login und Tool-Listen verwenden jedoch `WebSocketService`, wodurch eine fehlende Dokumentation zu Verbindungsfehlern wie 404-Handshakes führt. **(resolved)**
 - Fehlt echtes Migrationsframework, Tabellen werden zur Laufzeit erzeugt.
+- Hive-Log-API lieferte immer nur die letzten 50 Einträge ohne Pagination. **(resolved)**

--- a/controllers/hiveController.js
+++ b/controllers/hiveController.js
@@ -22,8 +22,12 @@ async function listLogs(req, res, next) {
   try {
     await initDb();
     const pool = getPool();
+    const page = parseInt(req.query.page || '1', 10);
+    const limit = parseInt(req.query.limit || '50', 10);
+    const offset = (page - 1) * limit;
     const { rows } = await pool.query(
-      'SELECT id, timestamp, type, message FROM activity_log ORDER BY id DESC LIMIT 50'
+      'SELECT id, timestamp, type, message FROM activity_log ORDER BY id DESC LIMIT $1 OFFSET $2',
+      [limit, offset]
     );
     res.json(rows);
   } catch (err) {

--- a/controllers/workflowsController.js
+++ b/controllers/workflowsController.js
@@ -1,0 +1,26 @@
+const { initDb, getPool } = require('../db');
+const { addJob, processQueue } = require('../workflowQueue');
+
+async function executeWorkflow(req, res, next) {
+  const { id } = req.params;
+  try {
+    await initDb();
+    const pool = getPool();
+    const { rows } = await pool.query(
+      'SELECT id, project_id, name, definition FROM workflows WHERE id = $1',
+      [id]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    const workflow = rows[0];
+    addJob(workflow);
+    processQueue();
+    await pool.query('UPDATE workflows SET last_run = now() WHERE id = $1', [id]);
+    res.json({ queued: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { executeWorkflow };

--- a/docs/hive.md
+++ b/docs/hive.md
@@ -1,0 +1,15 @@
+# Hive Log API
+
+## GET /api/hive/logs
+Returns hive activity log entries.
+
+### Query Parameters
+- `page` - Page number, default `1`.
+- `limit` - Entries per page, default `50`.
+
+### Response
+```json
+[
+  {"id":1,"timestamp":"2025-01-01T00:00:00Z","type":"info","message":"started"}
+]
+```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,10 @@
+# Workflow Execution API
+
+## POST /api/workflows/:id/execute
+Queues a workflow for execution.
+
+### Response
+```json
+{ "queued": true }
+```
+Authentication via Bearer token required.

--- a/frontend/components/ProjectCreateModal.test.tsx
+++ b/frontend/components/ProjectCreateModal.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, fireEvent, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import ProjectCreateModal, { Template } from './ProjectCreateModal';
+
+describe('ProjectCreateModal', () => {
+  it('calls onCreate with values', () => {
+    const tmpl: Template[] = [{ name: 'Empty', description: '' }];
+    const spy = vi.fn();
+    const { getAllByRole, getByText } = render(
+      <ProjectCreateModal isOpen templates={tmpl} onCreate={spy} onClose={() => {}} />
+    );
+    const input = document.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'A' } });
+    fireEvent.click(getByText('Create Project'));
+    expect(spy).toHaveBeenCalledWith('A', '', 'Empty');
+  });
+});

--- a/frontend/components/ProjectCreateModal.tsx
+++ b/frontend/components/ProjectCreateModal.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { Modal, Button } from './UI';
+
+export interface Template {
+  name: string;
+  description: string;
+}
+
+interface Props {
+  isOpen: boolean;
+  templates: Template[];
+  onCreate: (name: string, desc: string, template: string) => void;
+  onClose: () => void;
+}
+
+const ProjectCreateModal: React.FC<Props> = ({ isOpen, templates, onCreate, onClose }) => {
+  const [name, setName] = useState('');
+  const [desc, setDesc] = useState('');
+  const [template, setTemplate] = useState(templates[0]?.name || '');
+
+  const handle = () => {
+    if (name.trim()) {
+      onCreate(name.trim(), desc.trim(), template);
+      setName('');
+      setDesc('');
+      setTemplate(templates[0]?.name || '');
+      onClose();
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Create New Project">
+      <div className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">Project Name</label>
+          <input className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-white focus:outline-none" value={name} onChange={e => setName(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">Description</label>
+          <textarea className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-white focus:outline-none" rows={3} value={desc} onChange={e => setDesc(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-3">Project Template</label>
+          <div className="space-y-3">
+            {templates.map(t => (
+              <div key={t.name} onClick={() => setTemplate(t.name)} className={`p-4 border rounded-lg cursor-pointer transition-all ${template === t.name ? 'border-cyan-500 bg-cyan-500/10' : 'border-slate-700 hover:border-slate-600'}`}> 
+                <h4 className="font-bold text-white">{t.name}</h4>
+                <p className="text-sm text-slate-400">{t.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="flex justify-end gap-4 pt-4">
+          <Button variant="secondary" onClick={onClose}>Cancel</Button>
+          <Button variant="primary" onClick={handle}>Create Project</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ProjectCreateModal;

--- a/frontend/components/ProjectList.test.tsx
+++ b/frontend/components/ProjectList.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import ProjectList from './ProjectList';
+import { Project } from '../types';
+
+describe('ProjectList', () => {
+  it('renders project names', () => {
+    const projects: Project[] = [{ id: '1', name: 'P', description: '', hives: [], template: 't', created_at: '' }];
+    const { getByText } = render(<ProjectList projects={projects} onSelect={() => {}} />);
+    expect(getByText('P')).toBeTruthy();
+  });
+});

--- a/frontend/components/ProjectList.tsx
+++ b/frontend/components/ProjectList.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Project } from '../types';
+import { Card } from './UI';
+
+interface Props {
+  projects: Project[];
+  onSelect: (id: string) => void;
+}
+
+const ProjectList: React.FC<Props> = ({ projects, onSelect }) => (
+  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    {projects.map(p => (
+      <Card key={p.id} onClick={() => onSelect(p.id)} className="hover:shadow-cyan-lg hover:-translate-y-1">
+        <h3 className="text-xl font-bold text-cyan-400 truncate">{p.name}</h3>
+        <p className="text-slate-400 mt-2 h-12 overflow-hidden">{p.description}</p>
+        <div className="mt-4 text-sm text-slate-500 flex justify-between">
+          <span>{p.hives.length} Hives</span>
+          <span className="bg-fuchsia-500/10 text-fuchsia-400 px-2 py-0.5 rounded-full text-xs font-semibold">
+            {p.template || 'Custom'}
+          </span>
+        </div>
+      </Card>
+    ))}
+  </div>
+);
+
+export default ProjectList;

--- a/frontend/components/views/ProjectSelector.tsx
+++ b/frontend/components/views/ProjectSelector.tsx
@@ -1,8 +1,10 @@
 
 import React, { useState } from 'react';
 import { Project } from '../../types';
-import { Card, Button, Modal } from '../UI';
+import { Button } from '../UI';
 import { LogoIcon, PlusIcon } from '../Icons';
+import ProjectList from '../ProjectList';
+import ProjectCreateModal from '../ProjectCreateModal';
 
 type TemplateType = 'Empty' | 'Web App' | 'Data Analysis';
 
@@ -20,18 +22,8 @@ interface ProjectSelectorProps {
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({ projects, onSelectProject, onCreateProject }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [newProjectName, setNewProjectName] = useState('');
-  const [newProjectDesc, setNewProjectDesc] = useState('');
-  const [selectedTemplate, setSelectedTemplate] = useState<TemplateType>('Empty');
-
-  const handleCreate = () => {
-    if (newProjectName.trim()) {
-      onCreateProject(newProjectName.trim(), newProjectDesc.trim(), selectedTemplate);
-      setNewProjectName('');
-      setNewProjectDesc('');
-      setSelectedTemplate('Empty');
-      setIsModalOpen(false);
-    }
+  const handleCreate = (name: string, desc: string, template: TemplateType) => {
+    onCreateProject(name, desc, template);
   };
 
   return (
@@ -51,61 +43,15 @@ const ProjectSelector: React.FC<ProjectSelectorProps> = ({ projects, onSelectPro
             </Button>
         </div>
         
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {projects.map((project) => (
-            <Card key={project.id} className="hover:shadow-cyan-lg hover:-translate-y-1" onClick={() => onSelectProject(project.id)}>
-              <h3 className="text-xl font-bold text-cyan-400 truncate">{project.name}</h3>
-              <p className="text-slate-400 mt-2 h-12 overflow-hidden">{project.description}</p>
-              <div className="mt-4 text-sm text-slate-500 flex justify-between">
-                <span>{project.hives.length} Hives</span>
-                <span className="bg-fuchsia-500/10 text-fuchsia-400 px-2 py-0.5 rounded-full text-xs font-semibold">{project.template || 'Custom'}</span>
-              </div>
-            </Card>
-          ))}
-        </div>
+        <ProjectList projects={projects} onSelect={onSelectProject} />
       </div>
 
-      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="Create New Project">
-        <div className="space-y-6">
-            <div>
-                <label htmlFor="projectName" className="block text-sm font-medium text-slate-300 mb-2">Project Name</label>
-                <input
-                    type="text"
-                    id="projectName"
-                    value={newProjectName}
-                    onChange={(e) => setNewProjectName(e.target.value)}
-                    className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-cyan-500"
-                    placeholder="e.g., My Awesome App"
-                />
-            </div>
-            <div>
-                <label htmlFor="projectDesc" className="block text-sm font-medium text-slate-300 mb-2">Description (Optional)</label>
-                <textarea
-                    id="projectDesc"
-                    value={newProjectDesc}
-                    onChange={(e) => setNewProjectDesc(e.target.value)}
-                    rows={3}
-                    className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-cyan-500"
-                    placeholder="Describe your project's goal"
-                />
-            </div>
-            <div>
-                 <label className="block text-sm font-medium text-slate-300 mb-3">Project Template</label>
-                 <div className="space-y-3">
-                    {templates.map(template => (
-                        <div key={template.name} onClick={() => setSelectedTemplate(template.name)} className={`p-4 border rounded-lg cursor-pointer transition-all ${selectedTemplate === template.name ? 'border-cyan-500 bg-cyan-500/10' : 'border-slate-700 hover:border-slate-600'}`}>
-                            <h4 className="font-bold text-white">{template.name}</h4>
-                            <p className="text-sm text-slate-400">{template.description}</p>
-                        </div>
-                    ))}
-                 </div>
-            </div>
-            <div className="flex justify-end gap-4 pt-4">
-                <Button variant="secondary" onClick={() => setIsModalOpen(false)}>Cancel</Button>
-                <Button variant="primary" onClick={handleCreate}>Create Project</Button>
-            </div>
-        </div>
-      </Modal>
+      <ProjectCreateModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onCreate={handleCreate}
+        templates={templates}
+      />
     </div>
   );
 };

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -86,7 +86,30 @@ Dieser Abschnitt beschreibt die wichtigsten wiederverwendbaren und Ansichts-Komp
 
 ---
 
-### 1.3. `Assistant.tsx`
+### 1.3. `ProjectList.tsx`
+
+- **Name & Pfad:** `ProjectList` (`/components/ProjectList.tsx`)
+- **Beschreibung:** Zeigt eine Liste von Projekten als Karten an.
+- **Props:**
+| Name | Typ | Beschreibung |
+|---|---|---|
+| `projects` | `Project[]` | Anzuzeigende Projekte |
+| `onSelect` | `(id: string) => void` | Klick-Handler für Projektkarten |
+
+### 1.4. `ProjectCreateModal.tsx`
+
+- **Name & Pfad:** `ProjectCreateModal` (`/components/ProjectCreateModal.tsx`)
+- **Beschreibung:** Modal zur Erstellung eines Projekts.
+- **Props:**
+| Name | Typ | Beschreibung |
+|---|---|---|
+| `isOpen` | `boolean` | Steuert Sichtbarkeit |
+| `onCreate` | `(name: string, desc: string, template: string) => void` | Callback zum Anlegen |
+| `onClose` | `() => void` | Schließt das Modal |
+
+---
+
+### 1.5. `Assistant.tsx`
 
 - **Name & Pfad:** `Assistant` (`/components/Assistant.tsx`)
 - **Beschreibung:** Die schwebende KI-Assistenten-Komponente, die sich unten rechts befindet. Sie verwaltet die Chat-UI, die Benutzereingabe (Text und Sprache) und den Zustand des Assistenten. Nutzt die Web Speech API für die Spracheingabe.

--- a/milestones.md
+++ b/milestones.md
@@ -168,6 +168,14 @@ The following sprints track short term progress inside the larger milestones.
 *End:* 2025-08-24  \
 *Lead:* Codex Team
 - [x] **Feature:** REST-Endpunkte f\u00fcr Projekte implementiert. (@backend-agent)
-- [ ] **Feature:** Workflow-Ausf\u00fchrungs-API mit Queue. (@backend-agent)
-- [ ] **Bugfix:** Hive-Log-API Pagination. (@backend-agent)
-- [ ] **Doc:** API-Dokumentation erg\u00e4nzt. (@doku-agent)
+- [x] **Feature:** Workflow-Ausf\u00fchrungs-API mit Queue. (@backend-agent)
+- [x] **Bugfix:** Hive-Log-API Pagination. (@backend-agent)
+- [x] **Doc:** API-Dokumentation erg\u00e4nzt. (@doku-agent)
+
+### Sprint Aug-29-2025
+*Start:* 2025-08-29  \
+*End:* 2025-08-31  \
+*Lead:* Codex Team
+- [ ] **Feature:** Worker zur Verarbeitung der Workflow-Queue. (@backend-agent)
+- [ ] **Feature:** REST-Endpunkte f\u00fcr Workflow CRUD. (@backend-agent)
+- [ ] **Doc:** Queue-Endpunkte dokumentieren. (@doku-agent)

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const { getStatus } = require('../controllers/statusController');
 const { listUsers } = require('../controllers/usersController');
 const { logActivity, listLogs, clearLogs } = require('../controllers/hiveController');
 const { createProject, listProjects } = require('../controllers/projectsController');
+const { executeWorkflow } = require('../controllers/workflowsController');
 const auth = require('../middlewares/auth');
 
 router.post('/auth/register', register);
@@ -23,6 +24,7 @@ router.get('/hive/logs', listLogs);
 router.delete('/hive/logs', auth, clearLogs);
 router.post('/projects', auth, createProject);
 router.get('/projects', auth, listProjects);
+router.post('/workflows/:id/execute', auth, executeWorkflow);
 
 router.all('/', (req, res) => res.status(405).json({ error: 'Method Not Allowed' }));
 

--- a/testcases.md
+++ b/testcases.md
@@ -36,3 +36,11 @@
    - Erstelle Projekt mit `POST /api/projects` und Token
    - Erwartet Antwort mit Projekt-ID
    - Rufe `GET /api/projects` auf und prüfe, dass das Projekt gelistet wird
+8. **Hive-Log Pagination**
+   - Erzeuge mehrere Logeinträge via `POST /api/hive/log`
+   - Rufe `GET /api/hive/logs?page=2&limit=1` auf
+   - Erwartet genau einen Eintrag
+9. **Workflow Execution Queue**
+   - Füge Workflow in Datenbank ein
+   - Sende `POST /api/workflows/:id/execute` mit Token
+   - Erwartet Antwort `{ queued: true }`

--- a/workflowQueue.js
+++ b/workflowQueue.js
@@ -1,0 +1,28 @@
+const queue = [];
+let processing = false;
+
+function addJob(workflow) {
+  queue.push(workflow);
+}
+
+function getQueue() {
+  return queue;
+}
+
+async function processQueue() {
+  if (processing) return;
+  processing = true;
+  while (queue.length > 0) {
+    const job = queue.shift();
+    await execute(job);
+  }
+  processing = false;
+}
+
+async function execute(job) {
+  // Placeholder for real workflow execution logic
+  await new Promise(res => setTimeout(res, 10));
+  console.log('executed workflow', job.id);
+}
+
+module.exports = { addJob, getQueue, processQueue };


### PR DESCRIPTION
## Summary
- add workflow queue module and execution API
- extend hive log API with pagination
- create ProjectList and ProjectCreateModal components
- update ProjectSelector to use new components
- document hive log and workflow execution APIs
- expand tests for queue and pagination
- update tasks and milestones

## Testing
- `node --test test/server.test.js`
- `npx vitest run --config frontend/vitest.config.ts` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6883bb4af624832e9899aaa1be88655c