### PR TITLE
Fix update script image pull fallback

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -146,7 +146,10 @@ update_nginx_conf
 
 info "Updating containers..."
 $SUDO docker compose down
-$SUDO docker compose pull
+if ! $SUDO docker compose pull; then
+  warn "Pull failed, building images locally..."
+  $SUDO docker compose build
+fi
 
 info "Restarting services..."
 FRONTEND_PORT="$FRONTEND_PORT" BACKEND_PORT="$BACKEND_PORT" \


### PR DESCRIPTION
## Summary
- ensure update.sh builds images if `docker compose pull` fails

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test` *(fails: Cannot read properties of undefined (reading 'change'))*

------
https://chatgpt.com/codex/tasks/task_e_6883ce8a9330832eaaafc74fe1c16743