### PR TITLE
Fix update rollback issues

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 PORT=3008
 FRONTEND_PORT=8080
-BACKEND_PORT=3008
+BACKEND_PORT=4000
+MCP_PORT=3008
 DATABASE_URL=postgres://flowuser:flowpass@localhost:5432/flowdb
 JWT_SECRET=devsecret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
## Summary
- update the `.env` defaults to avoid port conflicts
- remove obsolete `version` from `docker-compose.yml`
- stop all containers when running `update.sh`
- adjust backend port if it conflicts with MCP

## Testing
- `npm test` *(fails: Cannot find package 'knex')*

------
https://chatgpt.com/codex/tasks/task_e_6883e795d260832e92b042682ed603d6