### PR TITLE
Fix tests by installing mcp dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "mcp/server.js",
   "scripts": {
     "start": "npm --prefix mcp start",
-    "test": "NODE_ENV=test node --test test/docker.test.js && npm --prefix mcp test"
+    "test": "NODE_ENV=test node --test test/docker.test.js && npm --prefix mcp test",
+    "pretest": "npm --prefix mcp install"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- install mcp dependencies before running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e827435c832ebaa9e4364e238e0c