### PR TITLE
Add Dockerfile for frontend build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine as build
+WORKDIR /app
+
+# Copy frontend sources
+COPY . .
+
+# Install dependencies and build the production bundle
+RUN npm install \
+    && npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,3 +26,14 @@ Alternatively, append `?dev` to the import URLs in `index.html` to force the non
 
 If you see `net::ERR_CERT_COMMON_NAME_INVALID` for `/favicon.ico`, your local HTTPS certificate is likely misconfigured. Use HTTP during development or fix the certificate to remove the warning.
 
+
+## Build Docker Image
+
+Use the provided `Dockerfile` to create a production image:
+
+```bash
+docker build -t flowui-frontend .
+```
+
+This bundles the React app with Vite and serves it via Nginx.
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flow Weaver</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+    <style>
+      /* Custom Font */
+      body {
+        font-family: 'Inter', sans-serif;
+        background-color: #050608;
+        background-image: radial-gradient(ellipse at top, rgba(0, 255, 237, 0.05) 0%, transparent 50%),
+                          radial-gradient(ellipse at bottom, rgba(255, 0, 144, 0.05) 0%, transparent 50%);
+        color: #E0E0E0;
+        overflow: hidden;
+      }
+
+      /* Custom Scrollbar */
+      ::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+      }
+      ::-webkit-scrollbar-track {
+        background: rgba(15, 23, 42, 0.5);
+      }
+      ::-webkit-scrollbar-thumb {
+        background: #4A5568;
+        border-radius: 4px;
+      }
+      ::-webkit-scrollbar-thumb:hover {
+        background: #718096;
+      }
+
+      /* Custom Shadows */
+      .shadow-cyan { box-shadow: 0 0 15px rgba(0, 255, 237, 0.15); }
+      .shadow-cyan-lg { box-shadow: 0 0 25px rgba(0, 255, 237, 0.3); }
+      .shadow-magenta { box-shadow: 0 0 15px rgba(255, 0, 144, 0.15); }
+      .shadow-magenta-lg { box-shadow: 0 0 25px rgba(255, 0, 144, 0.3); }
+      .shadow-indigo-lg { box-shadow: 0 0 25px rgba(99, 102, 241, 0.3); }
+      .shadow-fuchsia-lg { box-shadow: 0 0 25px rgba(219, 39, 119, 0.3); }
+
+      /* Custom Animations */
+      @keyframes fade-in-up {
+        from {
+          opacity: 0;
+          transform: translateY(20px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      
+      @keyframes pulsate {
+        0%, 100% { transform: scale(1); box-shadow: 0 0 20px rgba(0, 255, 237, 0.2); }
+        50% { transform: scale(1.05); box-shadow: 0 0 30px rgba(0, 255, 237, 0.4); }
+      }
+
+      @keyframes listening {
+        0% { box-shadow: 0 0 0 0 rgba(219, 39, 119, 0.7); }
+        70% { box-shadow: 0 0 0 20px rgba(219, 39, 119, 0); }
+        100% { box-shadow: 0 0 0 0 rgba(219, 39, 119, 0); }
+      }
+
+      @keyframes thinking {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+      }
+
+      .animate-fade-in-up {
+        animation: fade-in-up 0.5s ease-out forwards;
+      }
+      .animate-pulsate {
+        animation: pulsate 2.5s infinite ease-in-out;
+      }
+      .animate-listening {
+        animation: listening 1.5s infinite cubic-bezier(0.215, 0.61, 0.355, 1);
+      }
+      .animate-thinking {
+        animation: thinking 1s linear infinite;
+      }
+
+      /* Assistant Chat Panel */
+      .assistant-panel {
+        position: fixed;
+        bottom: 2rem;
+        right: 2rem;
+        z-index: 50;
+      }
+
+      .assistant-chat-window {
+          width: 400px;
+          height: 600px;
+          max-height: 80vh;
+          background-color: rgba(15, 23, 42, 0.8);
+          backdrop-filter: blur(12px);
+          border: 1px solid #334155;
+          border-radius: 1.5rem;
+          box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+          transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+      }
+
+      .assistant-chat-header {
+          flex-shrink: 0;
+          padding: 1rem;
+          border-bottom: 1px solid #334155;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+      }
+
+      .assistant-chat-history {
+          flex-grow: 1;
+          overflow-y: auto;
+          padding: 1rem;
+          display: flex;
+          flex-direction: column-reverse; /* Newest messages at the bottom */
+      }
+      
+      .chat-history-inner {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+          padding-top: 1rem; /* Space for the first message from the top */
+      }
+
+      .assistant-chat-bubble {
+          animation: fade-in-up 0.3s ease-out forwards;
+          max-width: 85%;
+          padding: 0.75rem 1rem;
+          border-radius: 1.25rem;
+          word-wrap: break-word;
+          line-height: 1.4;
+      }
+
+      .assistant-chat-bubble.user {
+          background: linear-gradient(to top right, #6D28D9, #DB2777);
+          color: white;
+          align-self: flex-end;
+          border-bottom-right-radius: 0.25rem;
+      }
+
+      .assistant-chat-bubble.assistant {
+          background-color: #1E293B; /* slate-800 */
+          color: #E0E0E0;
+          align-self: flex-start;
+          border-bottom-left-radius: 0.25rem;
+      }
+      
+      .assistant-chat-bubble.system {
+          align-self: center;
+          background-color: transparent;
+          color: #94a3b8; /* slate-400 */
+          font-size: 0.75rem;
+          text-align: center;
+          padding: 0.25rem 0;
+      }
+
+      .assistant-input-area {
+          flex-shrink: 0;
+          padding: 1rem;
+          border-top: 1px solid #334155;
+          background-color: rgba(5, 6, 8, 0.5);
+      }
+
+      .assistant-input-wrapper {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+      }
+
+      .assistant-text-input {
+          flex-grow: 1;
+          background-color: #1E293B;
+          border: 1px solid #334155;
+          color: white;
+          border-radius: 0.75rem;
+          padding: 0.75rem 1rem;
+          font-size: 0.875rem;
+          resize: none;
+      }
+      .assistant-text-input:focus {
+          outline: none;
+          box-shadow: 0 0 0 2px #00FFED;
+          border-color: #00FFED;
+      }
+
+      .assistant-suggestion-chip {
+          cursor: pointer;
+          transition: all 0.2s;
+          border: 1px solid #334155;
+          background-color: rgba(30, 41, 59, 0.8);
+          color: #cbd5e1; /* slate-300 */
+          padding: 0.25rem 0.75rem;
+          border-radius: 9999px;
+          font-size: 0.875rem;
+          margin: 4px;
+          display: inline-block;
+      }
+      .assistant-suggestion-chip:hover {
+          background-color: rgba(0, 255, 237, 0.1);
+          border-color: rgba(0, 255, 237, 0.5);
+          color: white;
+      }
+
+    </style>
+  <script>
+    const devSuffix = location.search.includes('dev') ? '?dev' : '';
+    const imports = {
+      "react-dom/": `https://esm.sh/react-dom@^19.1.0/${devSuffix}`,
+      "@google/genai": "https://esm.sh/@google/genai@^1.11.0",
+      "recharts": "https://esm.sh/recharts@^3.1.0",
+      "react/": `https://esm.sh/react@^19.1.0/${devSuffix}`,
+      "react": `https://esm.sh/react@^19.1.0${devSuffix}`
+    };
+    const script = document.createElement('script');
+    script.type = 'importmap';
+    script.textContent = JSON.stringify({ imports });
+    document.currentScript.after(script);
+  </script>
+<link rel="stylesheet" href="/index.css">
+</head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/frontend/index.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -1,0 +1,26 @@
+import path from 'path';
+// Load Vite dynamically so this config also works when compiled by ts-node
+const loadVite = async () => await import('./node_modules/vite');
+
+export default async ({ mode }) => {
+  const { defineConfig, loadEnv } = await loadVite();
+  const rootDir = __dirname;
+  const env = loadEnv(mode, rootDir, '');
+  const apiKey = env.OPENROUTER_API_KEY || env.GEMINI_API_KEY;
+  return defineConfig({
+    root: rootDir,
+    build: {
+      outDir: path.resolve(rootDir, 'dist')
+    },
+    define: {
+      'process.env.API_KEY': JSON.stringify(apiKey),
+      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+      'process.env.OPENROUTER_API_KEY': JSON.stringify(env.OPENROUTER_API_KEY)
+    },
+    resolve: {
+      alias: {
+        '@': rootDir
+      }
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- add `frontend/Dockerfile` for standalone frontend builds
- copy index.html and config into frontend directory
- ignore frontend build artifacts with `.dockerignore`
- document Docker image creation in `frontend/README.md`

## Testing
- `npm test` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_688406ac8e2c832e82f91c1f8a2b6bb8