### PR TITLE
Fix backend Dockerfile entry point

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,4 +6,4 @@ COPY tsconfig.json knexfile.cjs ./
 COPY src ./src
 RUN npm run build
 EXPOSE 4000
-CMD ["node","dist/index.js"]
+CMD ["node","dist/src/index.js"]


### PR DESCRIPTION
## Summary
- ensure Dockerfile runs the generated backend entry point

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68844abc1e3c832e9a207c01c054385b