### PR TITLE
Implement workflow CRUD and worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-## Nächste Aufgaben (Sprint 7)
-1. Worker zur Verarbeitung der Workflow-Queue implementieren und an MCP anbinden.
-2. CRUD-Endpunkte für Workflows im REST-Backend ergänzen.
-3. Dokumentation der neuen Endpunkte in `backend.md` und `frontend/docs.md` erweitern.
+## Nächste Aufgaben (Sprint 8)
+1. Persistenz für Workflows in PostgreSQL implementieren und Queue darauf anpassen.
+2. Frontend an die neuen Workflow-API-Endpunkte anbinden (Listen, erstellen, ausführen).
+3. Automatisierte Tests für Workflow-CRUD und Worker schreiben.

--- a/BRAIN.md
+++ b/BRAIN.md
@@ -5,3 +5,4 @@
 - Migrations werden aktuell per SQL in initDb erstellt. Langfristig sollte ein dediziertes Tool wie Knex eingesetzt werden.
 - Backend roles implemented with users.role column
  
+- Workflow queue worker implemented using WebSocket to MCP.

--- a/backend.md
+++ b/backend.md
@@ -625,7 +625,16 @@ Graceful Degradation (würdevoller Leistungsabfall): Wenn ein abhängiger Dienst
 
 Durch die Kombination einer robusten Überwachungsstrategie mit diesen Fehlertoleranzmustern wird ein Backend-System geschaffen, das nicht nur leistungsstark, sondern auch widerstandsfähig und zuverlässig im Angesicht der unvermeidlichen Ausfälle in einer verteilten Umgebung ist.
 ## Workflow Queue und Worker
-Der Server stellt einen REST-Endpunkt `POST /queue/enqueue` bereit. Clients übermitteln dort die Ziel-`channel` sowie frei wählbare Nutzdaten. Die Aufgaben werden in einer In-Memory-Queue gespeichert und von einem Worker-Prozess in regelmäßigen Abständen abgearbeitet. Nach Abschluss sendet der Worker das Ergebnis als `{event:'message', channel, payload}` über die WebSocket-Verbindung an alle Abonnenten des Kanals.
+Workflows können über `POST /api/workflows/:id/execute` in eine In-Memory-Queue eingereiht werden. Ein Hintergrund-Worker verarbeitet die Queue und kommuniziert über WebSocket mit dem MCP-Server. Nach erfolgreicher Ausführung wird das Feld `lastRun` des Workflows aktualisiert.
+
+### Workflow CRUD Endpunkte
+
+- `GET /api/workflows` – Liste aller Workflows
+- `POST /api/workflows` – Neuen Workflow anlegen (`{ name, description, steps }`)
+- `GET /api/workflows/:id` – Details eines Workflows
+- `PUT /api/workflows/:id` – Workflow aktualisieren
+- `DELETE /api/workflows/:id` – Workflow löschen
+- `POST /api/workflows/:id/execute` – Workflow in die Queue einreihen
 
 ## Backend Setup
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,9 @@
         "jsonwebtoken": "^9.0.2",
         "knex": "^2.5.1",
         "morgan": "^1.10.0",
-        "pg": "^8.11.5"
+        "pg": "^8.11.5",
+        "uuid": "^9.0.1",
+        "ws": "^8.16.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
@@ -25,6 +27,8 @@
         "@types/jsonwebtoken": "^9.0.2",
         "@types/morgan": "^1.9.10",
         "@types/node": "^20.4.2",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.2.0"
       }
@@ -254,6 +258,23 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2245,6 +2266,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -2265,6 +2299,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,9 @@
     "jsonwebtoken": "^9.0.2",
     "knex": "^2.5.1",
     "morgan": "^1.10.0",
-    "pg": "^8.11.5"
+    "pg": "^8.11.5",
+    "uuid": "^9.0.1",
+    "ws": "^8.16.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
@@ -27,6 +29,8 @@
     "@types/jsonwebtoken": "^9.0.2",
     "@types/morgan": "^1.9.10",
     "@types/node": "^20.4.2",
+    "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.2.0"
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import authRoutes from './routes/authRoutes.js';
 import toolsRoutes from './routes/toolsRoutes.js';
 import workflowRoutes from './routes/workflowRoutes.js';
 import mcpProxy from './routes/mcpProxy.js';
+import { startWorker } from './worker.js';
 
 dotenv.config();
 
@@ -24,6 +25,7 @@ app.use('/mcp', mcpProxy);
 const PORT = Number(process.env.BACKEND_PORT) || 4000;
 
 if (process.env.NODE_ENV !== 'test') {
+  startWorker();
   app.listen(PORT, () => {
     console.log(`Backend listening on ${PORT}`);
   });

--- a/backend/src/routes/workflowRoutes.ts
+++ b/backend/src/routes/workflowRoutes.ts
@@ -1,9 +1,41 @@
 import { Router } from 'express';
+import workflowService from '../services/workflowService.js';
 
 const router = Router();
 
-router.all('*', (_req, res) => {
-  res.status(501).json({ error: 'not_implemented' });
+router.get('/', (_req, res) => {
+  res.json(workflowService.list());
+});
+
+router.post('/', (req, res) => {
+  const { name, description, steps } = req.body;
+  if (!name || !steps) return res.status(400).json({ error: 'invalid_body' });
+  const wf = workflowService.create({ name, description, steps });
+  res.status(201).json(wf);
+});
+
+router.get('/:id', (req, res) => {
+  const wf = workflowService.get(req.params.id);
+  if (!wf) return res.status(404).json({ error: 'not_found' });
+  res.json(wf);
+});
+
+router.put('/:id', (req, res) => {
+  const wf = workflowService.update(req.params.id, req.body);
+  if (!wf) return res.status(404).json({ error: 'not_found' });
+  res.json(wf);
+});
+
+router.delete('/:id', (req, res) => {
+  const ok = workflowService.remove(req.params.id);
+  if (!ok) return res.status(404).json({ error: 'not_found' });
+  res.json({ deleted: true });
+});
+
+router.post('/:id/execute', (req, res) => {
+  const ok = workflowService.enqueue(req.params.id);
+  if (!ok) return res.status(404).json({ error: 'not_found' });
+  res.json({ queued: true });
 });
 
 export default router;

--- a/backend/src/services/workflowService.ts
+++ b/backend/src/services/workflowService.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export interface WorkflowStep {
+  id: string;
+  name: string;
+  command: string;
+}
+
+export interface Workflow {
+  id: string;
+  name: string;
+  description: string;
+  steps: WorkflowStep[];
+  lastRun: string | null;
+}
+
+const workflows = new Map<string, Workflow>();
+const queue: string[] = [];
+
+export function list(): Workflow[] {
+  return Array.from(workflows.values());
+}
+
+export function get(id: string): Workflow | undefined {
+  return workflows.get(id);
+}
+
+export function create(data: Omit<Workflow, 'id' | 'lastRun'>): Workflow {
+  const workflow: Workflow = { ...data, id: uuidv4(), lastRun: null };
+  workflows.set(workflow.id, workflow);
+  return workflow;
+}
+
+export function update(id: string, data: Partial<Omit<Workflow, 'id' | 'lastRun'>>): Workflow | undefined {
+  const wf = workflows.get(id);
+  if (!wf) return undefined;
+  Object.assign(wf, data);
+  workflows.set(id, wf);
+  return wf;
+}
+
+export function remove(id: string): boolean {
+  return workflows.delete(id);
+}
+
+export function enqueue(id: string): boolean {
+  if (!workflows.has(id)) return false;
+  queue.push(id);
+  return true;
+}
+
+export function dequeue(): string | undefined {
+  return queue.shift();
+}
+
+export function markRun(id: string): void {
+  const wf = workflows.get(id);
+  if (wf) {
+    wf.lastRun = new Date().toISOString();
+  }
+}
+
+export default { list, get, create, update, remove, enqueue, dequeue, markRun };

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -1,0 +1,39 @@
+import WebSocket from 'ws';
+import dotenv from 'dotenv';
+import workflowService from './services/workflowService.js';
+
+dotenv.config();
+
+const MCP_URL = process.env.MCP_WS_URL || 'ws://mcp:3008';
+const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
+
+async function executeWorkflow(id: string) {
+  const wf = workflowService.get(id);
+  if (!wf) return;
+  const ws = new WebSocket(MCP_URL);
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+  ws.send(JSON.stringify({ token: JWT_SECRET }));
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const args = wf.steps.map(s => s.command);
+  ws.send(JSON.stringify({ event: 'tools/batch', args }));
+  ws.once('message', () => {
+    workflowService.markRun(id);
+    ws.close();
+  });
+}
+
+export function startWorker() {
+  setInterval(async () => {
+    const id = workflowService.dequeue();
+    if (id) {
+      try {
+        await executeWorkflow(id);
+      } catch (err) {
+        console.error('Workflow execution failed', err);
+      }
+    }
+  }, 1000);
+}

--- a/change.log
+++ b/change.log
@@ -43,3 +43,4 @@ FE-SAVELOAD: 7a8df9c 2025-07-24 session list + tool call persistence
 2025-09-05: Added role-based auth with PostgreSQL persistence and admin /api/users endpoint.
 fix(ProjectCreateModal): add placeholder/testid to input for robust testing
 2025-07-26: Split REST API and MCP service into separate TypeScript projects, added Dockerfiles, compose updates and docs.
+2025-07-26: Added workflow CRUD endpoints, queue worker execution and updated docs

--- a/deploy_log.md
+++ b/deploy_log.md
@@ -1,3 +1,4 @@
 2025-07-24, da5563f, failed
 2025-07-24, 963bda5, failed
 2025-07-24, 7a8df9c, failed
+2025-07-26, a4280db, pending

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,4 +1,24 @@
-# Workflow Execution API
+# Workflow API
+
+## GET /api/workflows
+Returns a list of all workflows.
+
+## POST /api/workflows
+Creates a new workflow.
+
+### Request Body
+```json
+{ "name": "string", "description": "string", "steps": [{"name":"step","command":"tool"}] }
+```
+
+## GET /api/workflows/:id
+Returns one workflow.
+
+## PUT /api/workflows/:id
+Updates a workflow.
+
+## DELETE /api/workflows/:id
+Deletes a workflow.
 
 ## POST /api/workflows/:id/execute
 Queues a workflow for execution.
@@ -7,4 +27,5 @@ Queues a workflow for execution.
 ```json
 { "queued": true }
 ```
-Authentication via Bearer token required.
+
+Authentication via Bearer token required for all endpoints.

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -370,3 +370,14 @@ Es werden die Standard-Breakpoints von Tailwind CSS verwendet:
 - `lg`: 1024px
 - `xl`: 1280px
 - `2xl`: 1536px
+
+## 5. REST API Endpoints
+
+### Workflow Management
+- `GET /api/workflows` – Liste aller Workflows.
+- `POST /api/workflows` – Neuen Workflow anlegen. Body: `{ name, description, steps }`.
+- `GET /api/workflows/:id` – Details eines Workflows abrufen.
+- `PUT /api/workflows/:id` – Workflow aktualisieren.
+- `DELETE /api/workflows/:id` – Workflow löschen.
+- `POST /api/workflows/:id/execute` – Workflow zur Ausführung in die Queue stellen.
+

--- a/milestones.md
+++ b/milestones.md
@@ -196,3 +196,5 @@ Implemented worker queue and new WebSocket client with heartbeat.
 Introduced REST backend with auth proxy and adjusted deployment scripts.
 ### Sprint 5 Summary
 Added role-based authentication with persistent database storage and admin user listing.
+### Sprint 7 Summary
+Implemented workflow CRUD API and queue worker communicating with MCP.

--- a/testcases.md
+++ b/testcases.md
@@ -42,3 +42,9 @@
    - Füge Workflow in Datenbank ein
    - Sende `POST /api/workflows/:id/execute` mit Token
    - Erwartet Antwort `{ queued: true }`
+10. **Workflow CRUD API**
+   - `POST /api/workflows` mit gültigen Daten
+   - Erwartet Response mit Workflow-ID
+   - `GET /api/workflows` liefert den neuen Workflow
+   - `PUT /api/workflows/:id` ändert Namen
+   - `DELETE /api/workflows/:id` entfernt ihn


### PR DESCRIPTION
## Summary
- implement in-memory Workflow service with queue
- add CRUD/execute routes for workflows
- run queue worker to call MCP via WebSocket
- document endpoints in backend and frontend docs
- update change log, milestones and tasks

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68845525635c832e8198bbbc5e8667fd