### PR TITLE
fix env copying in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,14 +194,14 @@ fi
 # Create service environment files for local development
 if [ ! -f backend/.env ]; then
   echo "### Creating backend/.env"
-  cp backend/.env.example backend/.env
+  $SUDO cp backend/.env.example backend/.env
   $SUDO sed -i "s#JWT_SECRET=.*#JWT_SECRET=${JWT_SECRET}#" backend/.env
   $SUDO sed -i "s#DATABASE_URL=.*#DATABASE_URL=${DATABASE_URL_VALUE}#" backend/.env
 fi
 
 if [ ! -f mcp/.env ]; then
   echo "### Creating mcp/.env"
-  cp mcp/.env.example mcp/.env
+  $SUDO cp mcp/.env.example mcp/.env
   $SUDO sed -i "s#JWT_SECRET=.*#JWT_SECRET=${JWT_SECRET}#" mcp/.env
 fi
 


### PR DESCRIPTION
## Summary
- ensure install.sh can create backend/mcp env files when run non-root

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68845a0dfc60832ea9d90919e64bc360