### PR TITLE
Implement project API and migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-## Nächste Aufgaben (Sprint 9)
-1. PostgreSQL-Migrationen aufsetzen und Workflows persistent speichern.
-2. Frontend an Workflow-Endpunkte anbinden (Listen, erstellen, ausführen).
-3. Unit-Tests für Profil-Endpunkt und Workflow-CRUD erweitern.
+## Nächste Aufgaben (Sprint 10)
+1. Projekt-API komplettieren und Frontend-CRUD integrieren.
+2. Login-/Logout-Flows stabilisieren und UI-Fehler anzeigen.
+3. Backend-Testausführung optimieren, hängende Handles vermeiden.

--- a/BRAIN.md
+++ b/BRAIN.md
@@ -7,3 +7,4 @@
  
 - Workflow queue worker implemented using WebSocket to MCP.
 Added secure /profile endpoint using JWT middleware to provide user info.
+- Sprint9: migrations for users/projects/workflows; workflows persisted

--- a/backend.md
+++ b/backend.md
@@ -660,4 +660,15 @@ curl -X POST http://localhost:4000/auth/register -H 'Content-Type: application/j
 curl http://localhost:4000/profile -H 'Authorization: Bearer <token>'
 ```
 
+### Projektendpunkte
+
+```
+curl -X POST http://localhost:4000/projects \
+     -H 'Authorization: Bearer <token>' \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"My Project","description":"desc"}'
+
+curl http://localhost:4000/projects -H 'Authorization: Bearer <token>'
+```
+
 Der WebSocket-Proxy ist unter `/mcp` verfügbar und leitet intern an den MCP-Service weiter.

--- a/backend/migrations/20250909000000_create_users.cjs
+++ b/backend/migrations/20250909000000_create_users.cjs
@@ -1,0 +1,14 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('users', table => {
+    table.increments('id').primary();
+    table.string('username').notNullable().unique();
+    table.string('email').notNullable().unique();
+    table.string('password_hash').notNullable();
+    table.string('role').notNullable().defaultTo('user');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('users');
+};

--- a/backend/migrations/20250909000100_create_projects.cjs
+++ b/backend/migrations/20250909000100_create_projects.cjs
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('projects', table => {
+    table.increments('id').primary();
+    table.integer('user_id').references('id').inTable('users').onDelete('CASCADE');
+    table.string('name').notNullable();
+    table.text('description');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('projects');
+};

--- a/backend/migrations/20250909000200_create_workflows.cjs
+++ b/backend/migrations/20250909000200_create_workflows.cjs
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('workflows', table => {
+    table.uuid('id').primary();
+    table.integer('user_id').references('id').inTable('users').onDelete('CASCADE');
+    table.string('name').notNullable();
+    table.text('description');
+    table.jsonb('steps').notNullable();
+    table.timestamp('last_run');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists('workflows');
+};

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -14,7 +14,7 @@ export async function register(req: Request, res: Response) {
   if (exists) return res.status(400).json({ error: 'user_exists' });
   const hash = await bcrypt.hash(password, 10);
   const user = await userService.create({ username, email, password_hash: hash });
-  const token = jwt.sign({ user: user.username }, JWT_SECRET, { expiresIn: '1h' });
+  const token = jwt.sign({ user: user.username, id: user.id }, JWT_SECRET, { expiresIn: '1h' });
   res.json({ token });
 }
 
@@ -27,6 +27,6 @@ export async function login(req: Request, res: Response) {
   if (!user) return res.status(401).json({ error: 'invalid_credentials' });
   const valid = await bcrypt.compare(password, user.password_hash);
   if (!valid) return res.status(401).json({ error: 'invalid_credentials' });
-  const token = jwt.sign({ user: user.username }, JWT_SECRET, { expiresIn: '1h' });
+  const token = jwt.sign({ user: user.username, id: user.id }, JWT_SECRET, { expiresIn: '1h' });
   res.json({ token });
 }

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -14,8 +14,7 @@ test('GET /health', async () => {
   const port = (server.address() as any).port;
   const res = await fetch(`http://localhost:${port}/health`);
   const data = await res.json();
-  server.close();
-  await once(server, "close");
   assert.deepStrictEqual(data, { status: 'ok' });
-  process.exit(0);
+  server.close();
+  await once(server, 'close');
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import authRoutes from './routes/authRoutes.js';
 import profileRoutes from './routes/profileRoutes.js';
 import toolsRoutes from './routes/toolsRoutes.js';
 import workflowRoutes from './routes/workflowRoutes.js';
+import projectRoutes from './routes/projectRoutes.js';
 import mcpProxy from './routes/mcpProxy.js';
 import { startWorker } from './worker.js';
 
@@ -22,6 +23,7 @@ app.use('/auth', authRoutes);
 app.use('/profile', profileRoutes);
 app.use('/tools', toolsRoutes);
 app.use('/workflows', workflowRoutes);
+app.use('/projects', projectRoutes);
 app.use('/mcp', mcpProxy);
 
 const PORT = Number(process.env.BACKEND_PORT) || 4000;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -5,6 +5,7 @@ const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
 export interface AuthRequest extends Request {
   user?: string;
+  userId?: number;
 }
 
 export function verifyToken(req: AuthRequest, res: Response, next: NextFunction) {
@@ -15,6 +16,7 @@ export function verifyToken(req: AuthRequest, res: Response, next: NextFunction)
   try {
     const payload = jwt.verify(token, JWT_SECRET) as any;
     req.user = payload.user;
+    req.userId = payload.id;
     next();
   } catch {
     res.status(401).json({ error: 'invalid_token' });

--- a/backend/src/profile.test.ts
+++ b/backend/src/profile.test.ts
@@ -1,0 +1,34 @@
+import assert from 'assert';
+import { once } from 'events';
+import { test } from 'node:test';
+import app from './index.js';
+
+async function startServer() {
+  const server = app.listen(0);
+  await once(server, 'listening');
+  return server;
+}
+
+async function registerAndLogin(port: number) {
+  const res = await fetch(`http://localhost:${port}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'u1', email: 'u1@test.com', password: 'p' })
+  });
+  const data = await res.json();
+  return data.token;
+}
+
+test('GET /profile returns user data', async () => {
+  const server = await startServer();
+  const port = (server.address() as any).port;
+  const token = await registerAndLogin(port);
+  const res = await fetch(`http://localhost:${port}/profile`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+  server.close();
+  await once(server, 'close');
+  assert.strictEqual(body.user.username, 'u1');
+  process.exit(0);
+});

--- a/backend/src/routes/profileRoutes.ts
+++ b/backend/src/routes/profileRoutes.ts
@@ -5,8 +5,8 @@ import userService from '../services/userService.js';
 const router = Router();
 
 router.get('/', verifyToken, async (req: AuthRequest, res) => {
-  if (!req.user) return res.status(401).json({ error: 'unauthorized' });
-  const user = await userService.findByUsername(req.user);
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const user = await userService.findById(req.userId);
   if (!user) return res.status(404).json({ error: 'not_found' });
   res.json({ user: { id: user.id, username: user.username, email: user.email } });
 });

--- a/backend/src/routes/projectRoutes.ts
+++ b/backend/src/routes/projectRoutes.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { verifyToken, AuthRequest } from '../middleware/auth.js';
+import projectService from '../services/projectService.js';
+
+const router = Router();
+
+router.post('/', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const { name, description } = req.body;
+  if (!name) return res.status(400).json({ error: 'name_required' });
+  const project = await projectService.create(req.userId, { name, description });
+  res.status(201).json(project);
+});
+
+router.get('/', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const projects = await projectService.list(req.userId);
+  res.json(projects);
+});
+
+router.get('/:id', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const id = Number(req.params.id);
+  const project = await projectService.get(req.userId, id);
+  if (!project) return res.status(404).json({ error: 'not_found' });
+  res.json(project);
+});
+
+export default router;

--- a/backend/src/routes/workflowRoutes.ts
+++ b/backend/src/routes/workflowRoutes.ts
@@ -1,40 +1,50 @@
 import { Router } from 'express';
 import workflowService from '../services/workflowService.js';
+import { verifyToken, AuthRequest } from '../middleware/auth.js';
 
 const router = Router();
 
-router.get('/', (_req, res) => {
-  res.json(workflowService.list());
+router.get('/', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const list = await workflowService.list(req.userId);
+  res.json(list);
 });
 
-router.post('/', (req, res) => {
+router.post('/', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
   const { name, description, steps } = req.body;
   if (!name || !steps) return res.status(400).json({ error: 'invalid_body' });
-  const wf = workflowService.create({ name, description, steps });
+  const wf = await workflowService.create(req.userId, { name, description, steps });
   res.status(201).json(wf);
 });
 
-router.get('/:id', (req, res) => {
-  const wf = workflowService.get(req.params.id);
-  if (!wf) return res.status(404).json({ error: 'not_found' });
+router.get('/:id', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const wf = await workflowService.get(req.params.id);
+  if (!wf || wf.user_id !== req.userId) return res.status(404).json({ error: 'not_found' });
   res.json(wf);
 });
 
-router.put('/:id', (req, res) => {
-  const wf = workflowService.update(req.params.id, req.body);
-  if (!wf) return res.status(404).json({ error: 'not_found' });
+router.put('/:id', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const wf = await workflowService.update(req.params.id, req.body);
+  if (!wf || wf.user_id !== req.userId) return res.status(404).json({ error: 'not_found' });
   res.json(wf);
 });
 
-router.delete('/:id', (req, res) => {
-  const ok = workflowService.remove(req.params.id);
-  if (!ok) return res.status(404).json({ error: 'not_found' });
+router.delete('/:id', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const wf = await workflowService.get(req.params.id);
+  if (!wf || wf.user_id !== req.userId) return res.status(404).json({ error: 'not_found' });
+  await workflowService.remove(req.params.id);
   res.json({ deleted: true });
 });
 
-router.post('/:id/execute', (req, res) => {
-  const ok = workflowService.enqueue(req.params.id);
-  if (!ok) return res.status(404).json({ error: 'not_found' });
+router.post('/:id/execute', verifyToken, async (req: AuthRequest, res) => {
+  if (!req.userId) return res.status(401).json({ error: 'unauthorized' });
+  const wf = await workflowService.get(req.params.id);
+  if (!wf || wf.user_id !== req.userId) return res.status(404).json({ error: 'not_found' });
+  workflowService.enqueue(req.params.id);
   res.json({ queued: true });
 });
 

--- a/backend/src/services/projectService.ts
+++ b/backend/src/services/projectService.ts
@@ -1,0 +1,36 @@
+import knexModule from 'knex';
+import config from '../../knexfile.cjs';
+
+const knex = typeof (knexModule as any).default === 'function'
+  ? (knexModule as any).default
+  : (knexModule as any);
+
+const db = knex({
+  ...config,
+  connection: process.env.DATABASE_URL || (config as any).connection
+});
+
+export interface Project {
+  id: number;
+  user_id: number;
+  name: string;
+  description: string | null;
+  created_at: string;
+}
+
+export async function create(userId: number, data: { name: string; description?: string }): Promise<Project> {
+  const [p] = await db('projects')
+    .insert({ user_id: userId, name: data.name, description: data.description })
+    .returning('*');
+  return p as Project;
+}
+
+export async function list(userId: number): Promise<Project[]> {
+  return db('projects').where({ user_id: userId }).orderBy('created_at', 'desc');
+}
+
+export async function get(userId: number, id: number): Promise<Project | undefined> {
+  return db('projects').where({ id, user_id: userId }).first();
+}
+
+export default { create, list, get };

--- a/backend/src/worker.ts
+++ b/backend/src/worker.ts
@@ -8,7 +8,7 @@ const MCP_URL = process.env.MCP_WS_URL || 'ws://mcp:3008';
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
 async function executeWorkflow(id: string) {
-  const wf = workflowService.get(id);
+  const wf = await workflowService.get(id);
   if (!wf) return;
   const ws = new WebSocket(MCP_URL);
   await new Promise((resolve, reject) => {

--- a/backend/src/workflow.test.ts
+++ b/backend/src/workflow.test.ts
@@ -1,0 +1,59 @@
+import assert from 'assert';
+import { once } from 'events';
+import { test } from 'node:test';
+import app from './index.js';
+
+async function startServer() {
+  const server = app.listen(0);
+  await once(server, 'listening');
+  return server;
+}
+
+async function register(port:number) {
+  const res = await fetch(`http://localhost:${port}/auth/register`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ username:'w1', email:'w1@test.com', password:'p' })
+  });
+  const data = await res.json();
+  return data.token;
+}
+
+test('workflow CRUD', async () => {
+  const server = await startServer();
+  const port = (server.address() as any).port;
+  const token = await register(port);
+
+  const create = await fetch(`http://localhost:${port}/workflows`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ name: 'wf', description: '', steps: [] })
+  });
+  assert.strictEqual(create.status, 201);
+  const created = await create.json();
+
+  const listRes = await fetch(`http://localhost:${port}/workflows`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const list = await listRes.json();
+  assert.ok(list.length === 1);
+
+  const updateRes = await fetch(`http://localhost:${port}/workflows/${created.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ name: 'wf2' })
+  });
+  const updated = await updateRes.json();
+  assert.strictEqual(updated.name, 'wf2');
+
+  const delRes = await fetch(`http://localhost:${port}/workflows/${created.id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const delBody = await delRes.json();
+  assert.ok(delBody.deleted);
+
+  server.close();
+  await once(server, 'close');
+  process.exit(0);
+});

--- a/change.log
+++ b/change.log
@@ -1,4 +1,5 @@
 v0.2.0-alpha
+2025-09-06: Added database migrations, project endpoints and workflow persistence.
 DEPRECATION: Vollständige Entfernung der von Gemini generierten, nicht-funktionalen WebSocket-Platzhalterimplementierung.
 2025-08-22: Added project CRUD API and documentation.
 2025-08-08: Switched WebSocket endpoint to /ws, updated NGINX, frontend WebSocketService and tests.

--- a/deploy_log.md
+++ b/deploy_log.md
@@ -2,3 +2,4 @@
 2025-07-24, 963bda5, failed
 2025-07-24, 7a8df9c, failed
 2025-07-26, a4280db, pending
+2025-09-06: Added workflow and project migrations

--- a/frontend/components/views/ProjectSelector.tsx
+++ b/frontend/components/views/ProjectSelector.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Project } from '../../types';
 import { Button } from '../UI';
 import { LogoIcon, PlusIcon } from '../Icons';
+import { useAuth } from '../../hooks/useAuth';
 import ProjectList from '../ProjectList';
 import ProjectCreateModal from '../ProjectCreateModal';
 
@@ -22,12 +23,24 @@ interface ProjectSelectorProps {
 
 const ProjectSelector: React.FC<ProjectSelectorProps> = ({ projects, onSelectProject, onCreateProject }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const { user, logout } = useAuth();
   const handleCreate = (name: string, desc: string, template: TemplateType) => {
     onCreateProject(name, desc, template);
   };
 
   return (
     <div className="min-h-screen bg-[#050608] flex flex-col items-center justify-center p-8 text-white">
+      <div className="absolute top-4 right-4 text-sm">
+        <button onClick={() => setMenuOpen(v => !v)} className="px-3 py-2 bg-slate-800 rounded-lg border border-slate-700">
+          {user?.username}
+        </button>
+        {menuOpen && (
+          <div className="mt-2 bg-slate-800 border border-slate-700 rounded-lg shadow-xl">
+            <button className="block px-4 py-2 w-full text-left hover:bg-slate-700" onClick={logout}>Logout</button>
+          </div>
+        )}
+      </div>
       <div className="text-center mb-12 animate-fade-in-up">
         <LogoIcon className="h-24 w-24 mx-auto mb-4" />
         <h1 className="text-5xl font-black">Flow Weaver</h1>

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -386,3 +386,8 @@ Es werden die Standard-Breakpoints von Tailwind CSS verwendet:
 - `DELETE /api/workflows/:id` – Workflow löschen.
 - `POST /api/workflows/:id/execute` – Workflow zur Ausführung in die Queue stellen.
 
+### Projektverwaltung
+- `GET /api/projects` – Liste der Projekte des angemeldeten Nutzers
+- `POST /api/projects` – Neues Projekt erstellen `{ name, description }`
+- `GET /api/projects/:id` – Einzelnes Projekt abrufen
+

--- a/milestones.md
+++ b/milestones.md
@@ -200,3 +200,5 @@ Added role-based authentication with persistent database storage and admin user 
 Implemented workflow CRUD API and queue worker communicating with MCP.
 ### Sprint 8 Summary
 Implemented secure profile endpoint and updated frontend.
+### Sprint 9 Summary
+Added migrations with persistent workflows, project API and frontend integration.


### PR DESCRIPTION
## Summary
- add knex migrations for users, projects and workflows
- persist workflows in PostgreSQL via updated service
- secure auth payload with userId in JWT and expose project endpoints
- add user dropdown with logout on project selection screen
- fetch project list from backend and create new projects via REST
- document new API endpoints
- update change log, milestones and deploy log
- add initial backend tests for profile and workflows

## Testing
- `npm test --prefix backend` *(fails: hung during test execution)*

------
https://chatgpt.com/codex/tasks/task_e_688461627804832ea98a640e6ce4a034