### PR TITLE
Fix unauthorized project fetch

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -148,10 +148,21 @@ const App: React.FC = () => {
   const [projects, setProjects] = useState<Project[]>([]);
 
   useEffect(() => {
-    fetch('/api/projects')
-      .then(res => res.json())
-      .then(setProjects)
-      .catch(() => setProjects([]));
+    const loadProjects = async () => {
+      try {
+        const res = await fetch('/api/projects');
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data)) setProjects(data);
+          else setProjects([]);
+        } else {
+          setProjects([]);
+        }
+      } catch {
+        setProjects([]);
+      }
+    };
+    loadProjects();
   }, []);
   const [activeProject, setActiveProject] = useState<Project | null>(null);
   const [currentView, setCurrentView] = useState<View>('dashboard');

--- a/frontend/hooks/useAuth.tsx
+++ b/frontend/hooks/useAuth.tsx
@@ -24,6 +24,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
+    const originalFetch = window.fetch;
+    window.fetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      const headers = new Headers(init.headers || {});
+      if (token) headers.set('Authorization', `Bearer ${token}`);
+      return originalFetch(input, { ...init, headers });
+    };
+    return () => {
+      window.fetch = originalFetch;
+    };
+  }, [token]);
+
+  useEffect(() => {
     wsService.setAuthToken(token);
   }, [token]);
 
@@ -43,18 +55,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     };
     fetchProfile();
-  }, [token]);
-
-  useEffect(() => {
-    const originalFetch = window.fetch;
-    window.fetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
-      const headers = new Headers(init.headers || {});
-      if (token) headers.set('Authorization', `Bearer ${token}`);
-      return originalFetch(input, { ...init, headers });
-    };
-    return () => {
-      window.fetch = originalFetch;
-    };
   }, [token]);
 
   const login = async (username: string, password: string) => {


### PR DESCRIPTION
## Summary
- wrap global fetch interceptor before other auth effects to ensure token headers
- guard project list fetching against failed responses

## Testing
- `npm test` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6884ac363e28832ebd0f8ffa7c5b87a9