### PR TITLE
Improve auth workflow

### DIFF
--- a/backend.md
+++ b/backend.md
@@ -658,8 +658,12 @@ npm run dev
 curl http://localhost:4000/health
 curl -X POST http://localhost:4000/auth/register -H 'Content-Type: application/json' \
      -d '{"username":"u","email":"e@example.com","password":"p"}'
+curl -X POST http://localhost:4000/auth/login -H 'Content-Type: application/json' \
+     -d '{"username":"u","password":"p"}'
 curl http://localhost:4000/profile -H 'Authorization: Bearer <token>'
 ```
+
+Der Login-Endpunkt akzeptiert im Feld `username` auch eine E-Mail-Adresse. Bei der Registrierung werden Benutzername und E-Mail auf Einzigartigkeit geprüft. Passwörter werden mit `bcrypt` gehasht gespeichert.
 
 ### Projektendpunkte
 

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import { once } from 'events';
+import { test } from 'node:test';
+import app from './index.js';
+import db from './db.js';
+import userService from './services/userService.js';
+
+async function startServer() {
+  await db.migrate.latest();
+  const server = app.listen(0);
+  await once(server, 'listening');
+  return server;
+}
+
+test('registration hashes password and login via email works', async () => {
+  const server = await startServer();
+  const port = (server.address() as any).port;
+
+  const regRes = await fetch(`http://localhost:${port}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'a1', email: 'a1@test.com', password: 'p' })
+  });
+  assert.strictEqual(regRes.status, 200);
+  const regData = await regRes.json();
+  assert.ok(regData.token);
+
+  const user = await userService.findByUsername('a1');
+  assert(user);
+  assert.notStrictEqual(user!.password_hash, 'p');
+
+  const loginRes = await fetch(`http://localhost:${port}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'a1@test.com', password: 'p' })
+  });
+  assert.strictEqual(loginRes.status, 200);
+  const loginData = await loginRes.json();
+  assert.ok(loginData.token);
+
+  server.close();
+  await once(server, 'close');
+  await db.destroy();
+});

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -3,6 +3,8 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import userService from '../services/userService.js';
 
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
 export async function register(req: Request, res: Response) {
@@ -10,8 +12,13 @@ export async function register(req: Request, res: Response) {
   if (!username || !email || !password) {
     return res.status(400).json({ error: 'username, email and password required' });
   }
+  if (!emailRegex.test(email)) {
+    return res.status(400).json({ error: 'invalid_email' });
+  }
   const exists = await userService.findByUsername(username);
   if (exists) return res.status(400).json({ error: 'user_exists' });
+  const emailExists = await userService.findByEmail(email);
+  if (emailExists) return res.status(400).json({ error: 'email_exists' });
   const hash = await bcrypt.hash(password, 10);
   const user = await userService.create({ username, email, password_hash: hash });
   const token = jwt.sign({ user: user.username, id: user.id }, JWT_SECRET, { expiresIn: '1h' });
@@ -23,7 +30,10 @@ export async function login(req: Request, res: Response) {
   if (!username || !password) {
     return res.status(400).json({ error: 'username and password required' });
   }
-  const user = await userService.findByUsername(username);
+  let user = await userService.findByUsername(username);
+  if (!user && username.includes('@')) {
+    user = await userService.findByEmail(username);
+  }
   if (!user) return res.status(401).json({ error: 'invalid_credentials' });
   const valid = await bcrypt.compare(password, user.password_hash);
   if (!valid) return res.status(401).json({ error: 'invalid_credentials' });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,11 @@ import { initWs } from './ws.js';
 
 dotenv.config();
 
+if (!process.env.JWT_SECRET) {
+  console.error('JWT_SECRET not set');
+  process.exit(1);
+}
+
 const app = express();
 app.use(express.json());
 app.use(cors());

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -10,8 +10,12 @@ export async function findByUsername(username: string): Promise<User | undefined
   return db('users').where({ username }).first();
 }
 
+export async function findByEmail(email: string): Promise<User | undefined> {
+  return db('users').where({ email }).first();
+}
+
 export async function findById(id: number): Promise<User | undefined> {
   return db('users').where({ id }).first();
 }
 
-export default { create, findByUsername, findById };
+export default { create, findByUsername, findByEmail, findById };

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -374,9 +374,10 @@ Es werden die Standard-Breakpoints von Tailwind CSS verwendet:
 ## 5. REST API Endpoints
 
 ### Auth / Profile
-- `POST /api/auth/register` – Benutzer registrieren, Rückgabe `{ token }`.
-- `POST /api/auth/login` – Benutzer anmelden, Rückgabe `{ token }`.
+- `POST /api/auth/register` – Benutzer registrieren. Benötigt `username`, `email` und `password`. Gibt bei Erfolg `{ token }` zurück.
+- `POST /api/auth/login` – Benutzer anmelden. Das Feld `username` akzeptiert auch eine E‑Mail-Adresse. Rückgabe `{ token }`.
 - `GET /api/profile` – Profil des angemeldeten Benutzers abrufen. `Authorization: Bearer <token>` erforderlich.
+  Der Token wird im Frontend automatisch in `localStorage` gespeichert und bei nachfolgenden Requests als `Authorization`-Header mitsendet.
 
 ### Workflow Management
 - `GET /api/workflows` – Liste aller Workflows.


### PR DESCRIPTION
## Summary
- validate emails and check duplicates during registration
- allow login with email
- require `JWT_SECRET` at server start
- document auth flow and token handling
- add integration test for authentication

## Testing
- `npm test` *(fails: testCodeFailure)*

------
https://chatgpt.com/codex/tasks/task_e_6884b4b4a1a8832e913bb45325a87752