### PR TITLE
Fix auth token dispatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,7 @@
 1. Workflow-Queue um Log-Ausgabe erweitern: Backend-Endpunkt `/api/workflows/queue/:id/logs` implementieren und testen.
 2. WebSocket-Benachrichtigungen für Workflow-Fortschritt und Abschluss ausbauen und im Frontend live anzeigen.
 3. Dokumentation der neuen Log-API und WebSocket-Events in `docs/workflows.md` und `frontend/docs.md` ergänzen.
+
+### Authentifizierungs-Update
+Der globale `fetch`-Wrapper liest den JWT nun bei jedem Aufruf aus
+`localStorage` und fügt ihn automatisch als `Authorization`-Header ein.

--- a/backend.md
+++ b/backend.md
@@ -663,6 +663,10 @@ curl -X POST http://localhost:4000/auth/login -H 'Content-Type: application/json
 curl http://localhost:4000/profile -H 'Authorization: Bearer <token>'
 ```
 
+Die Middleware `verifyToken` prüft den Header `Authorization` und legt die
+Benutzer-ID unter `req.userId` ab. Bei fehlendem oder ungültigem Token
+antwortet der Server mit `401 Unauthorized`.
+
 Der Login-Endpunkt akzeptiert im Feld `username` auch eine E-Mail-Adresse. Bei der Registrierung werden Benutzername und E-Mail auf Einzigartigkeit geprüft. Passwörter werden mit `bcrypt` gehasht gespeichert.
 
 ### Projektendpunkte

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -377,7 +377,9 @@ Es werden die Standard-Breakpoints von Tailwind CSS verwendet:
 - `POST /api/auth/register` – Benutzer registrieren. Benötigt `username`, `email` und `password`. Gibt bei Erfolg `{ token }` zurück.
 - `POST /api/auth/login` – Benutzer anmelden. Das Feld `username` akzeptiert auch eine E‑Mail-Adresse. Rückgabe `{ token }`.
 - `GET /api/profile` – Profil des angemeldeten Benutzers abrufen. `Authorization: Bearer <token>` erforderlich.
-  Der Token wird im Frontend automatisch in `localStorage` gespeichert und bei nachfolgenden Requests als `Authorization`-Header mitsendet.
+  Der Token wird im Frontend in `localStorage` gespeichert. Eine globale `fetch`-
+  Erweiterung liest den gespeicherten Wert bei jedem Request aus und sendet ihn
+  als `Authorization`-Header mit.
 
 ### Workflow Management
 - `GET /api/workflows` – Liste aller Workflows.

--- a/frontend/hooks/useAuth.tsx
+++ b/frontend/hooks/useAuth.tsx
@@ -27,13 +27,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const originalFetch = window.fetch;
     window.fetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
       const headers = new Headers(init.headers || {});
-      if (token) headers.set('Authorization', `Bearer ${token}`);
+      const stored = localStorage.getItem('token');
+      if (stored) headers.set('Authorization', `Bearer ${stored}`);
       return originalFetch(input, { ...init, headers });
     };
     return () => {
       window.fetch = originalFetch;
     };
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     wsService.setAuthToken(token);


### PR DESCRIPTION
## Summary
- keep global fetch wrapper but read token from localStorage on each call
- document auth behaviour in frontend and backend docs
- note auth update in AGENTS.md

## Testing
- `npm --prefix backend test` *(fails: ECONNREFUSED for Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_6884bb525ba0832e9d30c4fddd1f3580