### PR TITLE
Add token debug logging for auth

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -9,9 +9,10 @@ export interface AuthRequest extends Request {
 }
 
 export function verifyToken(req: AuthRequest, res: Response, next: NextFunction) {
-  const auth = req.headers['authorization'];
-  if (!auth) return res.status(401).json({ error: 'missing_auth' });
-  const token = auth.split(' ')[1];
+  const authHeader = (req.headers['authorization'] || req.headers['Authorization']) as string | undefined;
+  console.log('Authorization header:', authHeader);
+  if (!authHeader) return res.status(401).json({ error: 'missing_auth' });
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : authHeader;
   if (!token) return res.status(401).json({ error: 'missing_auth' });
   try {
     const payload = jwt.verify(token, JWT_SECRET) as any;

--- a/frontend/hooks/useAuth.tsx
+++ b/frontend/hooks/useAuth.tsx
@@ -28,7 +28,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     window.fetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
       const headers = new Headers(init.headers || {});
       const stored = localStorage.getItem('token');
-      if (stored) headers.set('Authorization', `Bearer ${stored}`);
+      if (stored) {
+        console.log('Attaching token to request', stored);
+        headers.set('Authorization', `Bearer ${stored}`);
+      }
       return originalFetch(input, { ...init, headers });
     };
     return () => {
@@ -44,6 +47,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const fetchProfile = async () => {
       if (!token) { setUser(null); return; }
       try {
+        console.log('Fetching profile with token', token);
         const res = await fetch('/api/profile');
         if (res.ok) {
           const data = await res.json();
@@ -66,6 +70,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     });
     if (res.ok) {
       const data = await res.json();
+      console.log('Received token', data.token);
       localStorage.setItem('token', data.token);
       setToken(data.token);
       return true;


### PR DESCRIPTION
## Summary
- log incoming `Authorization` header in backend auth middleware
- output token usage in frontend `useAuth` hooks

## Testing
- `JWT_SECRET=devsecret npm test` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6884c65f0bd4832e83f4d96c48781c89