### PR TITLE
Make debug API page public

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@
 
 ### Debug-Tools
 Die Route `/debug-api` bietet eine einfache Testseite für API-Requests.
-Nur für Entwicklungszwecke nutzen!
+Sie ist **nicht geschützt** und kann ohne Login aufgerufen werden.
+Nur für Entwicklungs- und Testzwecke nutzen!
 
 ### Authentifizierungs-Update
 Der globale `fetch`-Wrapper liest den JWT nun bei jedem Aufruf aus

--- a/frontend/components/views/DebugApiView.tsx
+++ b/frontend/components/views/DebugApiView.tsx
@@ -45,7 +45,7 @@ const DebugApiView: React.FC = () => {
 
   return (
     <div className="p-4 space-y-4 animate-fade-in-up">
-      <h1 className="text-2xl font-bold text-white">API Debugger <span className="text-sm text-red-500">nur für Testzwecke!</span></h1>
+      <h1 className="text-2xl font-bold text-white">API Debugger <span className="text-sm text-red-500">Nur für Entwicklungs- und Testzwecke</span></h1>
       <div className="flex flex-col gap-2 max-w-xl">
         <input className="p-2 rounded bg-slate-800 border border-slate-700" value={url} onChange={e => setUrl(e.target.value)} placeholder="URL" />
         <select className="p-2 rounded bg-slate-800 border border-slate-700" value={method} onChange={e => setMethod(e.target.value)}>

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -408,5 +408,5 @@ Der Status `cancelled` wird dabei rot hervorgehoben.
 
 ### Debug API
 - **Route:** `/debug-api`
-- **Beschreibung:** Manuelle Testseite, um beliebige API-Requests abzusetzen. Eingabe von URL, HTTP-Methode, Headern und Body möglich. Nach dem Absenden werden Request- und Response-Daten inklusive Statuscode und Headern angezeigt. Nur für Debug-Zwecke verwenden.
+- **Beschreibung:** Manuelle Testseite, um beliebige API-Requests abzusetzen. Eingabe von URL, HTTP-Methode, Headern und Body möglich. Nach dem Absenden werden Request- und Response-Daten inklusive Statuscode und Headern angezeigt. Nur für Debug-Zwecke verwenden. Diese Route ist **nicht geschützt** und kann ohne Login im Browser aufgerufen werden.
 - **Komponente:** `DebugApiView` unter `frontend/components/views/DebugApiView.tsx`.

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { AuthProvider } from './hooks/useAuth';
+import DebugApiView from './components/views/DebugApiView';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -14,7 +16,12 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <AuthProvider>
-      <App />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/debug-api" element={<DebugApiView />} />
+          <Route path="/*" element={<App />} />
+        </Routes>
+      </BrowserRouter>
     </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@google/genai": "^1.11.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.7.1",
         "reactflow": "^11.9.0",
         "recharts": "^3.1.0"
       },
@@ -1874,6 +1875,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3750,6 +3760,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.1.tgz",
+      "integrity": "sha512-jVKHXoWRIsD/qS6lvGveckwb862EekvapdHJN/cGmzw40KnJH5gg53ujOJ4qX6EKIK9LSBfFed/xiQ5yeXNrUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.1.tgz",
+      "integrity": "sha512-bavdk2BA5r3MYalGKZ01u8PGuDBloQmzpBZVhDLrOOv1N943Wq6dcM9GhB3x8b7AbqPMEezauv4PeGkAJfy7FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/reactflow": {
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
@@ -3967,6 +4015,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@google/genai": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.7.1",
     "reactflow": "^11.9.0",
     "recharts": "^3.1.0"
   },


### PR DESCRIPTION
## Summary
- integrate react-router and expose `/debug-api` route
- allow access without login and show warning
- document the public debug page
- mention in AGENTS notes

## Testing
- `npm test` in `backend` *(fails: JWT_SECRET not set)*
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6884cac565d4832e84245fa15ff69b6a