### PR TITLE
Fix public debug route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 ### Debug-Tools
 Die Route `/debug-api` bietet eine einfache Testseite für API-Requests.
 Sie ist ausdrücklich **nicht** geschützt und kann ohne Login aufgerufen werden.
+Die Implementierung in `frontend/index.tsx` liegt daher außerhalb des `AuthProvider`.
 Nur für Entwicklungszwecke nutzen!
 
 ### Authentifizierungs-Update

--- a/frontend/docs.md
+++ b/frontend/docs.md
@@ -408,5 +408,5 @@ Der Status `cancelled` wird dabei rot hervorgehoben.
 
 ### Debug API
 - **Route:** `/debug-api`
-- **Beschreibung:** Manuelle Testseite, um beliebige API-Requests abzusetzen. Eingabe von URL, HTTP-Methode, Headern und Body möglich. Nach dem Absenden werden Request- und Response-Daten inklusive Statuscode und Headern angezeigt. **Zugriff ohne Login möglich, nur für Entwicklungs- und Testzwecke nutzen.**
+- **Beschreibung:** Manuelle Testseite, um beliebige API-Requests abzusetzen. Eingabe von URL, HTTP-Methode, Headern und Body möglich. Nach dem Absenden werden Request- und Response-Daten inklusive Statuscode und Headern angezeigt. **Zugriff ohne Login möglich, nur für Entwicklungs- und Testzwecke nutzen.** Die Route liegt bewusst außerhalb des `AuthProvider` in `frontend/index.tsx` und ist damit öffentlich.
 - **Komponente:** `DebugApiView` unter `frontend/components/views/DebugApiView.tsx`.

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -15,13 +15,18 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/debug-api" element={<DebugApiView />} />
-          <Route path="*" element={<App />} />
-        </Routes>
-      </BrowserRouter>
-    </AuthProvider>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/debug-api" element={<DebugApiView />} />
+        <Route
+          path="*"
+          element={
+            <AuthProvider>
+              <App />
+            </AuthProvider>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- keep `DebugApiView` outside `AuthProvider` so `/debug-api` is public
- clarify in docs and agents guidelines that `/debug-api` is intentionally unauthenticated

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6884cfabb734832ea5477dfc0d68c39f