### PR TITLE
Fix update script to build local images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,9 @@ Nur für Entwicklungszwecke nutzen!
 ### Authentifizierungs-Update
 Der globale `fetch`-Wrapper liest den JWT nun bei jedem Aufruf aus
 `localStorage` und fügt ihn automatisch als `Authorization`-Header ein.
+
+### Build-Strategie
+Container-Images werden **nicht** mehr von GHCR oder anderen Registries
+gezogen. `update.sh` baut stets die lokalen `Dockerfile`s neu und startet die
+Container mit `docker compose up -d --build`. Es soll kein CI-gesteuerter
+Image-Pull stattfinden.

--- a/deploy_log.md
+++ b/deploy_log.md
@@ -5,3 +5,4 @@
 2025-09-06: Added workflow and project migrations
 2025-09-08: Backend now runs knex migrations on startup, compose updated
 2025-09-09: Added queue endpoint and frontend view
+2025-07-26: Updated update.sh to always build local Docker images instead of pulling

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - pgdata:/var/lib/postgresql/data
 
   mcp:
-    image: ${MCP_IMAGE:-ghcr.io/meinzeug/flowui-mcp:latest}
     build:
       context: ./mcp
     depends_on:
@@ -23,7 +22,6 @@ services:
     command: sh -c "npx knex --knexfile knexfile.cjs migrate:latest && npm start"
 
   backend:
-    image: ${BACKEND_IMAGE:-ghcr.io/meinzeug/flowui-backend:latest}
     build:
       context: ./backend
     depends_on:
@@ -37,7 +35,6 @@ services:
       - "${BACKEND_PORT:-4000}:4000"
 
   frontend:
-    image: ${FRONTEND_IMAGE:-ghcr.io/meinzeug/flowui-frontend:latest}
     build:
       context: .
       dockerfile: Dockerfile

--- a/update.sh
+++ b/update.sh
@@ -190,14 +190,12 @@ update_nginx_conf
 info "Updating containers..."
 stop_all_containers
 $SUDO docker compose down
-if ! $SUDO docker compose pull; then
-  warn "Pull failed, building images locally..."
-  $SUDO docker compose build
-fi
+info "Building images locally..."
+$SUDO docker compose build --no-cache
 
 info "Restarting services..."
 FRONTEND_PORT="$FRONTEND_PORT" BACKEND_PORT="$BACKEND_PORT" \
-  $SUDO docker compose up -d
+  $SUDO docker compose up -d --build
 
 info "Performing health checks..."
 sleep 5


### PR DESCRIPTION
## Summary
- don't pull prebuilt containers in update.sh
- drop image tags from docker-compose.yml
- document local build strategy in AGENTS.md
- log update strategy in deploy_log.md

## Testing
- `npm test` *(fails: auth tests exit with ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6884d9e0bf60832eaba6c0bfb5809583