### PR TITLE
Fix logs display and ensure build passes

### DIFF
--- a/frontend/components/WorkflowQueue.tsx
+++ b/frontend/components/WorkflowQueue.tsx
@@ -72,7 +72,10 @@ const WorkflowQueue: React.FC = () => {
                     setOpenId(item.id);
                     if (!logs[item.id]) {
                       const res = await fetch(`/api/workflows/queue/${item.id}/logs`);
-                      if (res.ok) setLogs(l => ({ ...l, [item.id]: await res.json() }));
+                      if (res.ok) {
+                        const data = await res.json();
+                        setLogs(l => ({ ...l, [item.id]: data }));
+                      }
                     }
                   }}
                 >


### PR DESCRIPTION
## Summary
- fix `await` usage in workflow queue log viewer

## Testing
- `npm test` *(fails: test code failure)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688502e78ce4832ea080acb141303a0e