### PR TITLE
Handle invalid JSON body

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import morgan from 'morgan';
 import dotenv from 'dotenv';
@@ -23,6 +23,12 @@ if (!process.env.JWT_SECRET) {
 
 const app = express();
 app.use(express.json());
+app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+  if (err instanceof SyntaxError && 'body' in err) {
+    return res.status(400).json({ error: 'invalid_json' });
+  }
+  next(err);
+});
 app.use(cors());
 app.use(morgan('dev'));
 

--- a/backend/src/workflow.test.ts
+++ b/backend/src/workflow.test.ts
@@ -28,6 +28,26 @@ async function register(port:number) {
   return data.token;
 }
 
+test('create workflow with empty body returns 400', async () => {
+  const server = await startServer();
+  const port = (server.address() as any).port;
+  const token = await register(port);
+
+  const res = await fetch(`http://localhost:${port}/workflows`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: ''
+  });
+
+  assert.strictEqual(res.status, 400);
+  const body = await res.json();
+  assert.strictEqual(body.error, 'invalid_json');
+
+  server.close();
+  await once(server, 'close');
+  await db.destroy();
+});
+
 test('workflow CRUD', async () => {
   const server = await startServer();
   const port = (server.address() as any).port;


### PR DESCRIPTION
## Summary
- add middleware for invalid JSON parsing
- test POST /workflows with empty body

## Testing
- `JWT_SECRET=test npm test` *(fails: ECONNREFUSED)*
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `npm --prefix mcp run build`


------
https://chatgpt.com/codex/tasks/task_e_688538110018832e90c8d7f060694770